### PR TITLE
Fix V2Account key mess up

### DIFF
--- a/app/src/main/java/wannabit/io/cosmostaion/activities/txs/wc/WalletConnectActivity.kt
+++ b/app/src/main/java/wannabit/io/cosmostaion/activities/txs/wc/WalletConnectActivity.kt
@@ -1205,9 +1205,9 @@ class WalletConnectActivity : BaseActivity() {
         val key = getKey(account.baseChain)
         return key?.let {
             V2Account(
-                account.address,
-                Utils.bytesToHex(it.pubKey),
                 "secp256k1",
+                Utils.bytesToHex(it.pubKey),
+                account.address,
             )
         }
     }


### PR DESCRIPTION
The definition of V2Account is 

```
    data class V2Account(
        val algo: String,
        val pubkey: String,
        val address: String,
    )
 ```
https://github.com/cosmostation/cosmostation-android/blob/187a2a3a88a20ff1bde4b119a008b5682ed169d0/app/src/main/java/wannabit/io/cosmostaion/activities/txs/wc/WalletConnectActivity.kt#L1207

 The order was wrong