### PR TITLE
Fix V2Account pubkey should be in base64 format

### DIFF
--- a/app/src/main/java/wannabit/io/cosmostaion/activities/txs/wc/WalletConnectActivity.kt
+++ b/app/src/main/java/wannabit/io/cosmostaion/activities/txs/wc/WalletConnectActivity.kt
@@ -1206,7 +1206,7 @@ class WalletConnectActivity : BaseActivity() {
         return key?.let {
             V2Account(
                 "secp256k1",
-                Utils.bytesToHex(it.pubKey),
+                Base64.encodeToString(it.pubKey, Base64.NO_WRAP),
                 account.address,
             )
         }


### PR DESCRIPTION
https://docs.walletconnect.com/2.0/advanced/rpc-reference/cosmos-rpc#example
In spec pubkey is expected to be a base64 string instead of hex
I'm not quite sure which base64 encoding option I should use, would be nice if you guys can help confirm the change works and doesn't break stuff