### PR TITLE
Fix typos in localized `strings.xml` files

### DIFF
--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -366,7 +366,7 @@
     <string name="error_invalid_password">PIN 番号が違います</string>
     <string name="error_account_name">アカウント名を入力してください。</string>
     <string name="error_exist_account_name">すでに存在する名前です。</string>
-    <string name="error_invalid_menmonic">正しい復旧文字を入力してください。</string>
+    <string name="error_invalid_mnemonic">正しい復旧文字を入力してください。</string>
     <string name="error_invalid_private_Key">無効な秘密鍵です。</string>
     <string name="error_invalid_amount">有効でない数量です</string>
     <string name="error_not_enough_fee">Tx手数料を支払う利用可能金額が不足しています。</string>
@@ -552,7 +552,7 @@
     <string name="tx_send_nft_token_id">トークン ID</string>
     <string name="tx_send_nft_denom_id">Denom ID</string>
     <string name="tx_irismod_farm_stake">ファーミング</string>
-    <string name="tx_irismod_farm_Harvest">ファーミング 解除</string>
+    <string name="tx_irismod_farm_harvest">ファーミング 解除</string>
 
     <string name="tx_save_profile">プロファイルを保存</string>
     <string name="tx_link_chain_account">アカウントをリンク</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -323,7 +323,7 @@
     <string name="str_show_all_proposals_msg">모든 프로포절을 표시합니다.</string>
     <string name="str_hide_scam_proposals">스캠의심 프로포절을 필터합니다.</string>
     <string name="str_data_synchronizing">데이터 동기화중입니다</string>
-    <string name="str_enter_encryption_msg">계정을 복원하기 위해 화면에 표시된 Encription Key를 입력하세요.</string>
+    <string name="str_enter_encryption_msg">계정을 복원하기 위해 화면에 표시된 Encryption Key를 입력하세요.</string>
     <string name="str_broadcasting_msg">현재 트랜잭션이 실행 중입니다.\n잠시만 기다려 주세요.</string>
     <string name="str_addressbook_memo_changed_msg">기존 주소록과 비교해서 메모가 변경되었습니다.\n새로운 메모로 업데이트 하시겠습니까?</string>
     <string name="str_token_github_msg">모든 자산 및 토큰에 대한 정보는 커뮤니티와 함께 발전시키고 있습니다.\n\n본인의 토큰이 보이지 않는다면 아래 깃헙링크를 토큰 발행자나 커뮤니티에 알려주세요.\n\n토큰에 대한 정보가 등록되면 자동으로 지갑 및 민트스캔에 표시되며,\n고객님 뿐만 아니라 커뮤니티의 모든 사용자가 같이 확인하고 사용할 수 있습니다. </string>
@@ -364,7 +364,7 @@
     <string name="error_invalid_password">PIN 번호가 틀렸습니다.</string>
     <string name="error_account_name">계정 이름을 정확히 입력하세요.</string>
     <string name="error_exist_account_name">이미 존재하는 이름입니다.</string>
-    <string name="error_invalid_menmonic">정확한 복구문자를 입력해 주세요.</string>
+    <string name="error_invalid_mnemonic">정확한 복구문자를 입력해 주세요.</string>
     <string name="error_invalid_private_Key">유효하지 않는 개인키 입니다.</string>
     <string name="error_invalid_amount">유효하지 않는 수량입니다</string>
     <string name="error_not_enough_fee">Tx 수수료를 지불 할\n사용가능 금액이 부족합니다.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -483,8 +483,8 @@
     <string name="error_invalid_password">Invalid PIN number</string>
     <string name="error_account_name">Please insert account name.</string>
     <string name="error_exist_account_name">Already exist name.</string>
-    <string name="error_invalid_menmonic">Please insert valid mnemonics.</string>
-    <string name="error_invalid_private_Key">Invalid private key.</string>
+    <string name="error_invalid_mnemonic">Please insert valid mnemonics.</string>
+    <string name="error_invalid_private_key">Invalid private key.</string>
     <string name="error_invalid_amount">Invalid amount</string>
     <string name="error_not_enough_fee">Not enough available balance\nfor fee.</string>
     <string name="error_invalid_address">Invalid Address, please check again.</string>
@@ -506,7 +506,7 @@
     <string name="error_name">Please enter your name correctly.</string>
     <string name="error_not_support">%1$s is an unsupported chain.</string>
     <string name="error_unknown_qr_code">Unknown QR Code.</string>
-    <string name="error_decrytion">Decryption error</string>
+    <string name="error_decryption">Decryption error</string>
     <string name="error_not_support_cancel_unbonding">This chain does not yet support unstaking cancellation.</string>
     <string name="error_evm_simul">Network with the node is not smooth. Please try again later.</string>
     <string name="error_tranfer_disabled">Send functionality of the selected chain is currently disabled.\nIt can be activated later through the onchain governance procedure.</string>


### PR DESCRIPTION
1. Japanese (`values-ja`)
  - Fixed typo: `menmonic` ➝ `mnemonic`
  - Unified capitalization: `Harvest` ➝ `harvest`

2. Korean (`values-ko`)
  - Corrected typo: `Encription Key` ➝ `Encryption Key`
  - Fixed typo: `menmonic` ➝ `mnemonic`

3. English (`values`)
  - Fixed typo: `menmonic` ➝ `mnemonic`
  - Corrected typo: `decrytion` ➝ `decryption`
  - Unified key naming: `error_invalid_private_Key` ➝ `error_invalid_private_key`