### PR TITLE
docs: fix typos in comment

### DIFF
--- a/proto/src/main/java/com/kava/swap/v1beta1/QueryProto.java
+++ b/proto/src/main/java/com/kava/swap/v1beta1/QueryProto.java
@@ -4393,7 +4393,7 @@ public final class QueryProto {
 
     /**
      * <pre>
-     * pool_id optionally fitlers deposits by pool id
+     * pool_id optionally filters deposits by pool id
      * </pre>
      *
      * <code>string pool_id = 2 [json_name = "poolId"];</code>
@@ -4402,7 +4402,7 @@ public final class QueryProto {
     java.lang.String getPoolId();
     /**
      * <pre>
-     * pool_id optionally fitlers deposits by pool id
+     * pool_id optionally filters deposits by pool id
      * </pre>
      *
      * <code>string pool_id = 2 [json_name = "poolId"];</code>
@@ -4531,7 +4531,7 @@ public final class QueryProto {
     private volatile java.lang.Object poolId_ = "";
     /**
      * <pre>
-     * pool_id optionally fitlers deposits by pool id
+     * pool_id optionally filters deposits by pool id
      * </pre>
      *
      * <code>string pool_id = 2 [json_name = "poolId"];</code>
@@ -4552,7 +4552,7 @@ public final class QueryProto {
     }
     /**
      * <pre>
-     * pool_id optionally fitlers deposits by pool id
+     * pool_id optionally filters deposits by pool id
      * </pre>
      *
      * <code>string pool_id = 2 [json_name = "poolId"];</code>
@@ -5096,7 +5096,7 @@ public final class QueryProto {
       private java.lang.Object poolId_ = "";
       /**
        * <pre>
-       * pool_id optionally fitlers deposits by pool id
+       * pool_id optionally filters deposits by pool id
        * </pre>
        *
        * <code>string pool_id = 2 [json_name = "poolId"];</code>
@@ -5116,7 +5116,7 @@ public final class QueryProto {
       }
       /**
        * <pre>
-       * pool_id optionally fitlers deposits by pool id
+       * pool_id optionally filters deposits by pool id
        * </pre>
        *
        * <code>string pool_id = 2 [json_name = "poolId"];</code>
@@ -5137,7 +5137,7 @@ public final class QueryProto {
       }
       /**
        * <pre>
-       * pool_id optionally fitlers deposits by pool id
+       * pool_id optionally filters deposits by pool id
        * </pre>
        *
        * <code>string pool_id = 2 [json_name = "poolId"];</code>
@@ -5154,7 +5154,7 @@ public final class QueryProto {
       }
       /**
        * <pre>
-       * pool_id optionally fitlers deposits by pool id
+       * pool_id optionally filters deposits by pool id
        * </pre>
        *
        * <code>string pool_id = 2 [json_name = "poolId"];</code>
@@ -5168,7 +5168,7 @@ public final class QueryProto {
       }
       /**
        * <pre>
-       * pool_id optionally fitlers deposits by pool id
+       * pool_id optionally filters deposits by pool id
        * </pre>
        *
        * <code>string pool_id = 2 [json_name = "poolId"];</code>

--- a/proto/src/main/java/com/stratos/evm/v1/TxProto.java
+++ b/proto/src/main/java/com/stratos/evm/v1/TxProto.java
@@ -4958,7 +4958,7 @@ public final class TxProto {
   }
   /**
    * <pre>
-   * DynamicFeeTx is the data of EIP-1559 dinamic fee transactions.
+   * DynamicFeeTx is the data of EIP-1559 dynamic fee transactions.
    * </pre>
    *
    * Protobuf type {@code stratos.evm.v1.DynamicFeeTx}

--- a/proto/src/main/java/com/zrchain/validation/StakingProto.java
+++ b/proto/src/main/java/com/zrchain/validation/StakingProto.java
@@ -178,7 +178,7 @@ public final class StakingProto {
 
   /**
    * <pre>
-   * Infraction indicates the infraction a validator commited.
+   * Infraction indicates the infraction a validator committed.
    * </pre>
    *
    * Protobuf enum {@code zrchain.validation.Infraction}


### PR DESCRIPTION
## Fix typos in comment

### Summary

This PR corrects several minor typos in comments and documentation across the codebase. The changes are non-functional and purely textual to improve clarity and maintain a clean, professional codebase.

### Details

- Corrected typos:
  - `fitlers ` → `filters`
  - `dinamic` → `dynamic`
  - `commited` → `committed`

These fixes help enhance readability and eliminate minor distractions during development and code reviews.

### Additional Info

No logic or functionality has been modified. All changes are restricted to comments or non-executable doc annotations.
