### PR TITLE
docs: fix typos in comment

### DIFF
--- a/proto/src/main/java/com/cosmos/tx/v1beta1/TxProto.java
+++ b/proto/src/main/java/com/cosmos/tx/v1beta1/TxProto.java
@@ -3058,7 +3058,7 @@ public final class TxProto {
 
     /**
      * <pre>
-     * tips have been depreacted and should not be used
+     * tips have been deprecated and should not be used
      * </pre>
      *
      * <code>.cosmos.tx.v1beta1.Tip tip = 6 [json_name = "tip", deprecated = true];</code>
@@ -3069,7 +3069,7 @@ public final class TxProto {
     @java.lang.Deprecated boolean hasTip();
     /**
      * <pre>
-     * tips have been depreacted and should not be used
+     * tips have been deprecated and should not be used
      * </pre>
      *
      * <code>.cosmos.tx.v1beta1.Tip tip = 6 [json_name = "tip", deprecated = true];</code>
@@ -3080,7 +3080,7 @@ public final class TxProto {
     @java.lang.Deprecated com.cosmos.tx.v1beta1.TxProto.Tip getTip();
     /**
      * <pre>
-     * tips have been depreacted and should not be used
+     * tips have been deprecated and should not be used
      * </pre>
      *
      * <code>.cosmos.tx.v1beta1.Tip tip = 6 [json_name = "tip", deprecated = true];</code>
@@ -3270,7 +3270,7 @@ public final class TxProto {
     private com.cosmos.tx.v1beta1.TxProto.Tip tip_;
     /**
      * <pre>
-     * tips have been depreacted and should not be used
+     * tips have been deprecated and should not be used
      * </pre>
      *
      * <code>.cosmos.tx.v1beta1.Tip tip = 6 [json_name = "tip", deprecated = true];</code>
@@ -3284,7 +3284,7 @@ public final class TxProto {
     }
     /**
      * <pre>
-     * tips have been depreacted and should not be used
+     * tips have been deprecated and should not be used
      * </pre>
      *
      * <code>.cosmos.tx.v1beta1.Tip tip = 6 [json_name = "tip", deprecated = true];</code>
@@ -3298,7 +3298,7 @@ public final class TxProto {
     }
     /**
      * <pre>
-     * tips have been depreacted and should not be used
+     * tips have been deprecated and should not be used
      * </pre>
      *
      * <code>.cosmos.tx.v1beta1.Tip tip = 6 [json_name = "tip", deprecated = true];</code>
@@ -4181,7 +4181,7 @@ public final class TxProto {
           com.cosmos.tx.v1beta1.TxProto.Tip, com.cosmos.tx.v1beta1.TxProto.Tip.Builder, com.cosmos.tx.v1beta1.TxProto.TipOrBuilder> tipBuilder_;
       /**
        * <pre>
-       * tips have been depreacted and should not be used
+       * tips have been deprecated and should not be used
        * </pre>
        *
        * <code>.cosmos.tx.v1beta1.Tip tip = 6 [json_name = "tip", deprecated = true];</code>
@@ -4194,7 +4194,7 @@ public final class TxProto {
       }
       /**
        * <pre>
-       * tips have been depreacted and should not be used
+       * tips have been deprecated and should not be used
        * </pre>
        *
        * <code>.cosmos.tx.v1beta1.Tip tip = 6 [json_name = "tip", deprecated = true];</code>
@@ -4211,7 +4211,7 @@ public final class TxProto {
       }
       /**
        * <pre>
-       * tips have been depreacted and should not be used
+       * tips have been deprecated and should not be used
        * </pre>
        *
        * <code>.cosmos.tx.v1beta1.Tip tip = 6 [json_name = "tip", deprecated = true];</code>
@@ -4231,7 +4231,7 @@ public final class TxProto {
       }
       /**
        * <pre>
-       * tips have been depreacted and should not be used
+       * tips have been deprecated and should not be used
        * </pre>
        *
        * <code>.cosmos.tx.v1beta1.Tip tip = 6 [json_name = "tip", deprecated = true];</code>
@@ -4249,7 +4249,7 @@ public final class TxProto {
       }
       /**
        * <pre>
-       * tips have been depreacted and should not be used
+       * tips have been deprecated and should not be used
        * </pre>
        *
        * <code>.cosmos.tx.v1beta1.Tip tip = 6 [json_name = "tip", deprecated = true];</code>
@@ -4272,7 +4272,7 @@ public final class TxProto {
       }
       /**
        * <pre>
-       * tips have been depreacted and should not be used
+       * tips have been deprecated and should not be used
        * </pre>
        *
        * <code>.cosmos.tx.v1beta1.Tip tip = 6 [json_name = "tip", deprecated = true];</code>
@@ -4289,7 +4289,7 @@ public final class TxProto {
       }
       /**
        * <pre>
-       * tips have been depreacted and should not be used
+       * tips have been deprecated and should not be used
        * </pre>
        *
        * <code>.cosmos.tx.v1beta1.Tip tip = 6 [json_name = "tip", deprecated = true];</code>
@@ -4301,7 +4301,7 @@ public final class TxProto {
       }
       /**
        * <pre>
-       * tips have been depreacted and should not be used
+       * tips have been deprecated and should not be used
        * </pre>
        *
        * <code>.cosmos.tx.v1beta1.Tip tip = 6 [json_name = "tip", deprecated = true];</code>
@@ -4316,7 +4316,7 @@ public final class TxProto {
       }
       /**
        * <pre>
-       * tips have been depreacted and should not be used
+       * tips have been deprecated and should not be used
        * </pre>
        *
        * <code>.cosmos.tx.v1beta1.Tip tip = 6 [json_name = "tip", deprecated = true];</code>

--- a/proto/src/main/java/com/cosmwasm/wasm/v1/ProposalProto.java
+++ b/proto/src/main/java/com/cosmwasm/wasm/v1/ProposalProto.java
@@ -1516,7 +1516,7 @@ public final class ProposalProto {
 
     /**
      * <pre>
-     * Label is optional metadata to be stored with a constract instance.
+     * Label is optional metadata to be stored with a construct instance.
      * </pre>
      *
      * <code>string label = 6 [json_name = "label"];</code>
@@ -1525,7 +1525,7 @@ public final class ProposalProto {
     java.lang.String getLabel();
     /**
      * <pre>
-     * Label is optional metadata to be stored with a constract instance.
+     * Label is optional metadata to be stored with a construct instance.
      * </pre>
      *
      * <code>string label = 6 [json_name = "label"];</code>
@@ -1843,7 +1843,7 @@ public final class ProposalProto {
     private volatile java.lang.Object label_ = "";
     /**
      * <pre>
-     * Label is optional metadata to be stored with a constract instance.
+     * Label is optional metadata to be stored with a construct instance.
      * </pre>
      *
      * <code>string label = 6 [json_name = "label"];</code>
@@ -1864,7 +1864,7 @@ public final class ProposalProto {
     }
     /**
      * <pre>
-     * Label is optional metadata to be stored with a constract instance.
+     * Label is optional metadata to be stored with a construct instance.
      * </pre>
      *
      * <code>string label = 6 [json_name = "label"];</code>
@@ -2922,7 +2922,7 @@ public final class ProposalProto {
       private java.lang.Object label_ = "";
       /**
        * <pre>
-       * Label is optional metadata to be stored with a constract instance.
+       * Label is optional metadata to be stored with a construct instance.
        * </pre>
        *
        * <code>string label = 6 [json_name = "label"];</code>
@@ -2942,7 +2942,7 @@ public final class ProposalProto {
       }
       /**
        * <pre>
-       * Label is optional metadata to be stored with a constract instance.
+       * Label is optional metadata to be stored with a construct instance.
        * </pre>
        *
        * <code>string label = 6 [json_name = "label"];</code>
@@ -2963,7 +2963,7 @@ public final class ProposalProto {
       }
       /**
        * <pre>
-       * Label is optional metadata to be stored with a constract instance.
+       * Label is optional metadata to be stored with a construct instance.
        * </pre>
        *
        * <code>string label = 6 [json_name = "label"];</code>
@@ -2980,7 +2980,7 @@ public final class ProposalProto {
       }
       /**
        * <pre>
-       * Label is optional metadata to be stored with a constract instance.
+       * Label is optional metadata to be stored with a construct instance.
        * </pre>
        *
        * <code>string label = 6 [json_name = "label"];</code>
@@ -2994,7 +2994,7 @@ public final class ProposalProto {
       }
       /**
        * <pre>
-       * Label is optional metadata to be stored with a constract instance.
+       * Label is optional metadata to be stored with a construct instance.
        * </pre>
        *
        * <code>string label = 6 [json_name = "label"];</code>


### PR DESCRIPTION
### Description

This PR corrects several minor typos in comments across the codebase. 

### Details

- Corrected misspellings:
  - `depreacted` → `deprecated`
  - `constract` → `construct`

These fixes help enhance readability and eliminate minor distractions during development and code reviews.

### Additional Info

No logic or functionality has been modified. All changes are restricted to comments or non-executable doc annotations.