### PR TITLE
fix typos in comment

### DIFF
--- a/proto/src/main/java/com/ethermint/evm/v1/GenesisProto.java
+++ b/proto/src/main/java/com/ethermint/evm/v1/GenesisProto.java
@@ -1178,7 +1178,7 @@ public final class GenesisProto {
 
     /**
      * <pre>
-     * address defines an ethereum hex formated address of an account
+     * address defines an ethereum hex formatted address of an account
      * </pre>
      *
      * <code>string address = 1 [json_name = "address"];</code>
@@ -1187,7 +1187,7 @@ public final class GenesisProto {
     java.lang.String getAddress();
     /**
      * <pre>
-     * address defines an ethereum hex formated address of an account
+     * address defines an ethereum hex formatted address of an account
      * </pre>
      *
      * <code>string address = 1 [json_name = "address"];</code>
@@ -1309,7 +1309,7 @@ public final class GenesisProto {
     private volatile java.lang.Object address_ = "";
     /**
      * <pre>
-     * address defines an ethereum hex formated address of an account
+     * address defines an ethereum hex formatted address of an account
      * </pre>
      *
      * <code>string address = 1 [json_name = "address"];</code>
@@ -1330,7 +1330,7 @@ public final class GenesisProto {
     }
     /**
      * <pre>
-     * address defines an ethereum hex formated address of an account
+     * address defines an ethereum hex formatted address of an account
      * </pre>
      *
      * <code>string address = 1 [json_name = "address"];</code>
@@ -1890,7 +1890,7 @@ public final class GenesisProto {
       private java.lang.Object address_ = "";
       /**
        * <pre>
-       * address defines an ethereum hex formated address of an account
+       * address defines an ethereum hex formatted address of an account
        * </pre>
        *
        * <code>string address = 1 [json_name = "address"];</code>
@@ -1910,7 +1910,7 @@ public final class GenesisProto {
       }
       /**
        * <pre>
-       * address defines an ethereum hex formated address of an account
+       * address defines an ethereum hex formatted address of an account
        * </pre>
        *
        * <code>string address = 1 [json_name = "address"];</code>
@@ -1931,7 +1931,7 @@ public final class GenesisProto {
       }
       /**
        * <pre>
-       * address defines an ethereum hex formated address of an account
+       * address defines an ethereum hex formatted address of an account
        * </pre>
        *
        * <code>string address = 1 [json_name = "address"];</code>
@@ -1948,7 +1948,7 @@ public final class GenesisProto {
       }
       /**
        * <pre>
-       * address defines an ethereum hex formated address of an account
+       * address defines an ethereum hex formatted address of an account
        * </pre>
        *
        * <code>string address = 1 [json_name = "address"];</code>
@@ -1962,7 +1962,7 @@ public final class GenesisProto {
       }
       /**
        * <pre>
-       * address defines an ethereum hex formated address of an account
+       * address defines an ethereum hex formatted address of an account
        * </pre>
        *
        * <code>string address = 1 [json_name = "address"];</code>

--- a/proto/src/main/java/com/stratos/evm/v1/GenesisProto.java
+++ b/proto/src/main/java/com/stratos/evm/v1/GenesisProto.java
@@ -1276,7 +1276,7 @@ public final class GenesisProto {
 
     /**
      * <pre>
-     * address defines an ethereum hex formated address of an account
+     * address defines an ethereum hex formatted address of an account
      * </pre>
      *
      * <code>string address = 1 [json_name = "address", (.gogoproto.jsontag) = "address", (.gogoproto.moretags) = "yaml:&#92;"address&#92;""];</code>
@@ -1285,7 +1285,7 @@ public final class GenesisProto {
     java.lang.String getAddress();
     /**
      * <pre>
-     * address defines an ethereum hex formated address of an account
+     * address defines an ethereum hex formatted address of an account
      * </pre>
      *
      * <code>string address = 1 [json_name = "address", (.gogoproto.jsontag) = "address", (.gogoproto.moretags) = "yaml:&#92;"address&#92;""];</code>
@@ -1407,7 +1407,7 @@ public final class GenesisProto {
     private volatile java.lang.Object address_ = "";
     /**
      * <pre>
-     * address defines an ethereum hex formated address of an account
+     * address defines an ethereum hex formatted address of an account
      * </pre>
      *
      * <code>string address = 1 [json_name = "address", (.gogoproto.jsontag) = "address", (.gogoproto.moretags) = "yaml:&#92;"address&#92;""];</code>
@@ -1428,7 +1428,7 @@ public final class GenesisProto {
     }
     /**
      * <pre>
-     * address defines an ethereum hex formated address of an account
+     * address defines an ethereum hex formatted address of an account
      * </pre>
      *
      * <code>string address = 1 [json_name = "address", (.gogoproto.jsontag) = "address", (.gogoproto.moretags) = "yaml:&#92;"address&#92;""];</code>
@@ -1988,7 +1988,7 @@ public final class GenesisProto {
       private java.lang.Object address_ = "";
       /**
        * <pre>
-       * address defines an ethereum hex formated address of an account
+       * address defines an ethereum hex formatted address of an account
        * </pre>
        *
        * <code>string address = 1 [json_name = "address", (.gogoproto.jsontag) = "address", (.gogoproto.moretags) = "yaml:&#92;"address&#92;""];</code>
@@ -2008,7 +2008,7 @@ public final class GenesisProto {
       }
       /**
        * <pre>
-       * address defines an ethereum hex formated address of an account
+       * address defines an ethereum hex formatted address of an account
        * </pre>
        *
        * <code>string address = 1 [json_name = "address", (.gogoproto.jsontag) = "address", (.gogoproto.moretags) = "yaml:&#92;"address&#92;""];</code>
@@ -2029,7 +2029,7 @@ public final class GenesisProto {
       }
       /**
        * <pre>
-       * address defines an ethereum hex formated address of an account
+       * address defines an ethereum hex formatted address of an account
        * </pre>
        *
        * <code>string address = 1 [json_name = "address", (.gogoproto.jsontag) = "address", (.gogoproto.moretags) = "yaml:&#92;"address&#92;""];</code>
@@ -2046,7 +2046,7 @@ public final class GenesisProto {
       }
       /**
        * <pre>
-       * address defines an ethereum hex formated address of an account
+       * address defines an ethereum hex formatted address of an account
        * </pre>
        *
        * <code>string address = 1 [json_name = "address", (.gogoproto.jsontag) = "address", (.gogoproto.moretags) = "yaml:&#92;"address&#92;""];</code>
@@ -2060,7 +2060,7 @@ public final class GenesisProto {
       }
       /**
        * <pre>
-       * address defines an ethereum hex formated address of an account
+       * address defines an ethereum hex formatted address of an account
        * </pre>
        *
        * <code>string address = 1 [json_name = "address", (.gogoproto.jsontag) = "address", (.gogoproto.moretags) = "yaml:&#92;"address&#92;""];</code>

--- a/proto/src/main/java/com/stratos/evm/v1/ProposalProto.java
+++ b/proto/src/main/java/com/stratos/evm/v1/ProposalProto.java
@@ -90,7 +90,7 @@ public final class ProposalProto {
   }
   /**
    * <pre>
-   * UpdateImplmentationProposal used to update implemntation for genesis proxies
+   * UpdateImplmentationProposal used to update implementation for genesis proxies
    * </pre>
    *
    * Protobuf type {@code stratos.evm.v1.UpdateImplmentationProposal}
@@ -476,7 +476,7 @@ public final class ProposalProto {
     }
     /**
      * <pre>
-     * UpdateImplmentationProposal used to update implemntation for genesis proxies
+     * UpdateImplmentationProposal used to update implementation for genesis proxies
      * </pre>
      *
      * Protobuf type {@code stratos.evm.v1.UpdateImplmentationProposal}


### PR DESCRIPTION
This PR fixes spelling mistakes in the documentation comments:

GenesisProto.java:

 - Fixed "formated" to "formatted" in comment
 - Fixed "transction" to "transaction" in comment

ProposalProto.java:

 - Fixed "implemntation" to "implementation" in comment

These changes improve code documentation readability and maintain consistent spelling throughout the codebase.