### PR TITLE
fix: correct typo in ChainBluzelle tag from "bluzellee118" to "bluzelle118"

### DIFF
--- a/app/src/main/java/wannabit/io/cosmostaion/chain/cosmosClass/ChainBluzelle.kt
+++ b/app/src/main/java/wannabit/io/cosmostaion/chain/cosmosClass/ChainBluzelle.kt
@@ -13,7 +13,7 @@ import wannabit.io.cosmostaion.chain.PubKeyType
 class ChainBluzelle : BaseChain(), Parcelable {
 
     override var name: String = "Bluzelle"
-    override var tag: String = "bluzellee118"
+    override var tag: String = "bluzelle118"
     override var apiName: String = "bluzelle"
 
     override var accountKeyType = AccountKeyType(PubKeyType.COSMOS_SECP256K1, "m/44'/483'/0'/0/X")


### PR DESCRIPTION
Fixed a typo in the ChainBluzelle class where the tag property had an extra 'e' character.
Changed "bluzellee118" to "bluzelle118" to ensure proper chain identification.

This fix prevents potential issues with chain recognition and maintains consistency
with the expected tag format for the Bluzelle blockchain.