### PR TITLE
docs: fix typos in comment

### DIFF
--- a/proto/src/main/java/com/cosmos/gov/v1/GenesisProto.java
+++ b/proto/src/main/java/com/cosmos/gov/v1/GenesisProto.java
@@ -163,7 +163,7 @@ public final class GenesisProto {
     /**
      * <pre>
      * Deprecated: Prefer to use `params` instead.
-     * deposit_params defines all the paramaters of related to deposit.
+     * deposit_params defines all the parameters of related to deposit.
      * </pre>
      *
      * <code>.cosmos.gov.v1.DepositParams deposit_params = 5 [json_name = "depositParams", deprecated = true];</code>
@@ -175,7 +175,7 @@ public final class GenesisProto {
     /**
      * <pre>
      * Deprecated: Prefer to use `params` instead.
-     * deposit_params defines all the paramaters of related to deposit.
+     * deposit_params defines all the parameters of related to deposit.
      * </pre>
      *
      * <code>.cosmos.gov.v1.DepositParams deposit_params = 5 [json_name = "depositParams", deprecated = true];</code>
@@ -187,7 +187,7 @@ public final class GenesisProto {
     /**
      * <pre>
      * Deprecated: Prefer to use `params` instead.
-     * deposit_params defines all the paramaters of related to deposit.
+     * deposit_params defines all the parameters of related to deposit.
      * </pre>
      *
      * <code>.cosmos.gov.v1.DepositParams deposit_params = 5 [json_name = "depositParams", deprecated = true];</code>
@@ -197,7 +197,7 @@ public final class GenesisProto {
     /**
      * <pre>
      * Deprecated: Prefer to use `params` instead.
-     * voting_params defines all the paramaters of related to voting.
+     * voting_params defines all the parameters of related to voting.
      * </pre>
      *
      * <code>.cosmos.gov.v1.VotingParams voting_params = 6 [json_name = "votingParams", deprecated = true];</code>
@@ -209,7 +209,7 @@ public final class GenesisProto {
     /**
      * <pre>
      * Deprecated: Prefer to use `params` instead.
-     * voting_params defines all the paramaters of related to voting.
+     * voting_params defines all the parameters of related to voting.
      * </pre>
      *
      * <code>.cosmos.gov.v1.VotingParams voting_params = 6 [json_name = "votingParams", deprecated = true];</code>
@@ -221,7 +221,7 @@ public final class GenesisProto {
     /**
      * <pre>
      * Deprecated: Prefer to use `params` instead.
-     * voting_params defines all the paramaters of related to voting.
+     * voting_params defines all the parameters of related to voting.
      * </pre>
      *
      * <code>.cosmos.gov.v1.VotingParams voting_params = 6 [json_name = "votingParams", deprecated = true];</code>
@@ -231,7 +231,7 @@ public final class GenesisProto {
     /**
      * <pre>
      * Deprecated: Prefer to use `params` instead.
-     * tally_params defines all the paramaters of related to tally.
+     * tally_params defines all the parameters of related to tally.
      * </pre>
      *
      * <code>.cosmos.gov.v1.TallyParams tally_params = 7 [json_name = "tallyParams", deprecated = true];</code>
@@ -243,7 +243,7 @@ public final class GenesisProto {
     /**
      * <pre>
      * Deprecated: Prefer to use `params` instead.
-     * tally_params defines all the paramaters of related to tally.
+     * tally_params defines all the parameters of related to tally.
      * </pre>
      *
      * <code>.cosmos.gov.v1.TallyParams tally_params = 7 [json_name = "tallyParams", deprecated = true];</code>
@@ -255,7 +255,7 @@ public final class GenesisProto {
     /**
      * <pre>
      * Deprecated: Prefer to use `params` instead.
-     * tally_params defines all the paramaters of related to tally.
+     * tally_params defines all the parameters of related to tally.
      * </pre>
      *
      * <code>.cosmos.gov.v1.TallyParams tally_params = 7 [json_name = "tallyParams", deprecated = true];</code>
@@ -264,7 +264,7 @@ public final class GenesisProto {
 
     /**
      * <pre>
-     * params defines all the paramaters of x/gov module.
+     * params defines all the parameters of x/gov module.
      *
      * Since: cosmos-sdk 0.47
      * </pre>
@@ -275,7 +275,7 @@ public final class GenesisProto {
     boolean hasParams();
     /**
      * <pre>
-     * params defines all the paramaters of x/gov module.
+     * params defines all the parameters of x/gov module.
      *
      * Since: cosmos-sdk 0.47
      * </pre>
@@ -286,7 +286,7 @@ public final class GenesisProto {
     com.cosmos.gov.v1.GovProto.Params getParams();
     /**
      * <pre>
-     * params defines all the paramaters of x/gov module.
+     * params defines all the parameters of x/gov module.
      *
      * Since: cosmos-sdk 0.47
      * </pre>
@@ -540,7 +540,7 @@ public final class GenesisProto {
     /**
      * <pre>
      * Deprecated: Prefer to use `params` instead.
-     * deposit_params defines all the paramaters of related to deposit.
+     * deposit_params defines all the parameters of related to deposit.
      * </pre>
      *
      * <code>.cosmos.gov.v1.DepositParams deposit_params = 5 [json_name = "depositParams", deprecated = true];</code>
@@ -555,7 +555,7 @@ public final class GenesisProto {
     /**
      * <pre>
      * Deprecated: Prefer to use `params` instead.
-     * deposit_params defines all the paramaters of related to deposit.
+     * deposit_params defines all the parameters of related to deposit.
      * </pre>
      *
      * <code>.cosmos.gov.v1.DepositParams deposit_params = 5 [json_name = "depositParams", deprecated = true];</code>
@@ -570,7 +570,7 @@ public final class GenesisProto {
     /**
      * <pre>
      * Deprecated: Prefer to use `params` instead.
-     * deposit_params defines all the paramaters of related to deposit.
+     * deposit_params defines all the parameters of related to deposit.
      * </pre>
      *
      * <code>.cosmos.gov.v1.DepositParams deposit_params = 5 [json_name = "depositParams", deprecated = true];</code>
@@ -585,7 +585,7 @@ public final class GenesisProto {
     /**
      * <pre>
      * Deprecated: Prefer to use `params` instead.
-     * voting_params defines all the paramaters of related to voting.
+     * voting_params defines all the parameters of related to voting.
      * </pre>
      *
      * <code>.cosmos.gov.v1.VotingParams voting_params = 6 [json_name = "votingParams", deprecated = true];</code>
@@ -600,7 +600,7 @@ public final class GenesisProto {
     /**
      * <pre>
      * Deprecated: Prefer to use `params` instead.
-     * voting_params defines all the paramaters of related to voting.
+     * voting_params defines all the parameters of related to voting.
      * </pre>
      *
      * <code>.cosmos.gov.v1.VotingParams voting_params = 6 [json_name = "votingParams", deprecated = true];</code>
@@ -615,7 +615,7 @@ public final class GenesisProto {
     /**
      * <pre>
      * Deprecated: Prefer to use `params` instead.
-     * voting_params defines all the paramaters of related to voting.
+     * voting_params defines all the parameters of related to voting.
      * </pre>
      *
      * <code>.cosmos.gov.v1.VotingParams voting_params = 6 [json_name = "votingParams", deprecated = true];</code>
@@ -630,7 +630,7 @@ public final class GenesisProto {
     /**
      * <pre>
      * Deprecated: Prefer to use `params` instead.
-     * tally_params defines all the paramaters of related to tally.
+     * tally_params defines all the parameters of related to tally.
      * </pre>
      *
      * <code>.cosmos.gov.v1.TallyParams tally_params = 7 [json_name = "tallyParams", deprecated = true];</code>
@@ -645,7 +645,7 @@ public final class GenesisProto {
     /**
      * <pre>
      * Deprecated: Prefer to use `params` instead.
-     * tally_params defines all the paramaters of related to tally.
+     * tally_params defines all the parameters of related to tally.
      * </pre>
      *
      * <code>.cosmos.gov.v1.TallyParams tally_params = 7 [json_name = "tallyParams", deprecated = true];</code>
@@ -660,7 +660,7 @@ public final class GenesisProto {
     /**
      * <pre>
      * Deprecated: Prefer to use `params` instead.
-     * tally_params defines all the paramaters of related to tally.
+     * tally_params defines all the parameters of related to tally.
      * </pre>
      *
      * <code>.cosmos.gov.v1.TallyParams tally_params = 7 [json_name = "tallyParams", deprecated = true];</code>
@@ -674,7 +674,7 @@ public final class GenesisProto {
     private com.cosmos.gov.v1.GovProto.Params params_;
     /**
      * <pre>
-     * params defines all the paramaters of x/gov module.
+     * params defines all the parameters of x/gov module.
      *
      * Since: cosmos-sdk 0.47
      * </pre>
@@ -688,7 +688,7 @@ public final class GenesisProto {
     }
     /**
      * <pre>
-     * params defines all the paramaters of x/gov module.
+     * params defines all the parameters of x/gov module.
      *
      * Since: cosmos-sdk 0.47
      * </pre>
@@ -702,7 +702,7 @@ public final class GenesisProto {
     }
     /**
      * <pre>
-     * params defines all the paramaters of x/gov module.
+     * params defines all the parameters of x/gov module.
      *
      * Since: cosmos-sdk 0.47
      * </pre>
@@ -2382,7 +2382,7 @@ public final class GenesisProto {
       /**
        * <pre>
        * Deprecated: Prefer to use `params` instead.
-       * deposit_params defines all the paramaters of related to deposit.
+       * deposit_params defines all the parameters of related to deposit.
        * </pre>
        *
        * <code>.cosmos.gov.v1.DepositParams deposit_params = 5 [json_name = "depositParams", deprecated = true];</code>
@@ -2396,7 +2396,7 @@ public final class GenesisProto {
       /**
        * <pre>
        * Deprecated: Prefer to use `params` instead.
-       * deposit_params defines all the paramaters of related to deposit.
+       * deposit_params defines all the parameters of related to deposit.
        * </pre>
        *
        * <code>.cosmos.gov.v1.DepositParams deposit_params = 5 [json_name = "depositParams", deprecated = true];</code>
@@ -2414,7 +2414,7 @@ public final class GenesisProto {
       /**
        * <pre>
        * Deprecated: Prefer to use `params` instead.
-       * deposit_params defines all the paramaters of related to deposit.
+       * deposit_params defines all the parameters of related to deposit.
        * </pre>
        *
        * <code>.cosmos.gov.v1.DepositParams deposit_params = 5 [json_name = "depositParams", deprecated = true];</code>
@@ -2435,7 +2435,7 @@ public final class GenesisProto {
       /**
        * <pre>
        * Deprecated: Prefer to use `params` instead.
-       * deposit_params defines all the paramaters of related to deposit.
+       * deposit_params defines all the parameters of related to deposit.
        * </pre>
        *
        * <code>.cosmos.gov.v1.DepositParams deposit_params = 5 [json_name = "depositParams", deprecated = true];</code>
@@ -2454,7 +2454,7 @@ public final class GenesisProto {
       /**
        * <pre>
        * Deprecated: Prefer to use `params` instead.
-       * deposit_params defines all the paramaters of related to deposit.
+       * deposit_params defines all the parameters of related to deposit.
        * </pre>
        *
        * <code>.cosmos.gov.v1.DepositParams deposit_params = 5 [json_name = "depositParams", deprecated = true];</code>
@@ -2478,7 +2478,7 @@ public final class GenesisProto {
       /**
        * <pre>
        * Deprecated: Prefer to use `params` instead.
-       * deposit_params defines all the paramaters of related to deposit.
+       * deposit_params defines all the parameters of related to deposit.
        * </pre>
        *
        * <code>.cosmos.gov.v1.DepositParams deposit_params = 5 [json_name = "depositParams", deprecated = true];</code>
@@ -2496,7 +2496,7 @@ public final class GenesisProto {
       /**
        * <pre>
        * Deprecated: Prefer to use `params` instead.
-       * deposit_params defines all the paramaters of related to deposit.
+       * deposit_params defines all the parameters of related to deposit.
        * </pre>
        *
        * <code>.cosmos.gov.v1.DepositParams deposit_params = 5 [json_name = "depositParams", deprecated = true];</code>
@@ -2509,7 +2509,7 @@ public final class GenesisProto {
       /**
        * <pre>
        * Deprecated: Prefer to use `params` instead.
-       * deposit_params defines all the paramaters of related to deposit.
+       * deposit_params defines all the parameters of related to deposit.
        * </pre>
        *
        * <code>.cosmos.gov.v1.DepositParams deposit_params = 5 [json_name = "depositParams", deprecated = true];</code>
@@ -2525,7 +2525,7 @@ public final class GenesisProto {
       /**
        * <pre>
        * Deprecated: Prefer to use `params` instead.
-       * deposit_params defines all the paramaters of related to deposit.
+       * deposit_params defines all the parameters of related to deposit.
        * </pre>
        *
        * <code>.cosmos.gov.v1.DepositParams deposit_params = 5 [json_name = "depositParams", deprecated = true];</code>
@@ -2550,7 +2550,7 @@ public final class GenesisProto {
       /**
        * <pre>
        * Deprecated: Prefer to use `params` instead.
-       * voting_params defines all the paramaters of related to voting.
+       * voting_params defines all the parameters of related to voting.
        * </pre>
        *
        * <code>.cosmos.gov.v1.VotingParams voting_params = 6 [json_name = "votingParams", deprecated = true];</code>
@@ -2564,7 +2564,7 @@ public final class GenesisProto {
       /**
        * <pre>
        * Deprecated: Prefer to use `params` instead.
-       * voting_params defines all the paramaters of related to voting.
+       * voting_params defines all the parameters of related to voting.
        * </pre>
        *
        * <code>.cosmos.gov.v1.VotingParams voting_params = 6 [json_name = "votingParams", deprecated = true];</code>
@@ -2582,7 +2582,7 @@ public final class GenesisProto {
       /**
        * <pre>
        * Deprecated: Prefer to use `params` instead.
-       * voting_params defines all the paramaters of related to voting.
+       * voting_params defines all the parameters of related to voting.
        * </pre>
        *
        * <code>.cosmos.gov.v1.VotingParams voting_params = 6 [json_name = "votingParams", deprecated = true];</code>
@@ -2603,7 +2603,7 @@ public final class GenesisProto {
       /**
        * <pre>
        * Deprecated: Prefer to use `params` instead.
-       * voting_params defines all the paramaters of related to voting.
+       * voting_params defines all the parameters of related to voting.
        * </pre>
        *
        * <code>.cosmos.gov.v1.VotingParams voting_params = 6 [json_name = "votingParams", deprecated = true];</code>
@@ -2622,7 +2622,7 @@ public final class GenesisProto {
       /**
        * <pre>
        * Deprecated: Prefer to use `params` instead.
-       * voting_params defines all the paramaters of related to voting.
+       * voting_params defines all the parameters of related to voting.
        * </pre>
        *
        * <code>.cosmos.gov.v1.VotingParams voting_params = 6 [json_name = "votingParams", deprecated = true];</code>
@@ -2646,7 +2646,7 @@ public final class GenesisProto {
       /**
        * <pre>
        * Deprecated: Prefer to use `params` instead.
-       * voting_params defines all the paramaters of related to voting.
+       * voting_params defines all the parameters of related to voting.
        * </pre>
        *
        * <code>.cosmos.gov.v1.VotingParams voting_params = 6 [json_name = "votingParams", deprecated = true];</code>
@@ -2664,7 +2664,7 @@ public final class GenesisProto {
       /**
        * <pre>
        * Deprecated: Prefer to use `params` instead.
-       * voting_params defines all the paramaters of related to voting.
+       * voting_params defines all the parameters of related to voting.
        * </pre>
        *
        * <code>.cosmos.gov.v1.VotingParams voting_params = 6 [json_name = "votingParams", deprecated = true];</code>
@@ -2677,7 +2677,7 @@ public final class GenesisProto {
       /**
        * <pre>
        * Deprecated: Prefer to use `params` instead.
-       * voting_params defines all the paramaters of related to voting.
+       * voting_params defines all the parameters of related to voting.
        * </pre>
        *
        * <code>.cosmos.gov.v1.VotingParams voting_params = 6 [json_name = "votingParams", deprecated = true];</code>
@@ -2693,7 +2693,7 @@ public final class GenesisProto {
       /**
        * <pre>
        * Deprecated: Prefer to use `params` instead.
-       * voting_params defines all the paramaters of related to voting.
+       * voting_params defines all the parameters of related to voting.
        * </pre>
        *
        * <code>.cosmos.gov.v1.VotingParams voting_params = 6 [json_name = "votingParams", deprecated = true];</code>
@@ -2718,7 +2718,7 @@ public final class GenesisProto {
       /**
        * <pre>
        * Deprecated: Prefer to use `params` instead.
-       * tally_params defines all the paramaters of related to tally.
+       * tally_params defines all the parameters of related to tally.
        * </pre>
        *
        * <code>.cosmos.gov.v1.TallyParams tally_params = 7 [json_name = "tallyParams", deprecated = true];</code>
@@ -2732,7 +2732,7 @@ public final class GenesisProto {
       /**
        * <pre>
        * Deprecated: Prefer to use `params` instead.
-       * tally_params defines all the paramaters of related to tally.
+       * tally_params defines all the parameters of related to tally.
        * </pre>
        *
        * <code>.cosmos.gov.v1.TallyParams tally_params = 7 [json_name = "tallyParams", deprecated = true];</code>
@@ -2750,7 +2750,7 @@ public final class GenesisProto {
       /**
        * <pre>
        * Deprecated: Prefer to use `params` instead.
-       * tally_params defines all the paramaters of related to tally.
+       * tally_params defines all the parameters of related to tally.
        * </pre>
        *
        * <code>.cosmos.gov.v1.TallyParams tally_params = 7 [json_name = "tallyParams", deprecated = true];</code>
@@ -2771,7 +2771,7 @@ public final class GenesisProto {
       /**
        * <pre>
        * Deprecated: Prefer to use `params` instead.
-       * tally_params defines all the paramaters of related to tally.
+       * tally_params defines all the parameters of related to tally.
        * </pre>
        *
        * <code>.cosmos.gov.v1.TallyParams tally_params = 7 [json_name = "tallyParams", deprecated = true];</code>
@@ -2790,7 +2790,7 @@ public final class GenesisProto {
       /**
        * <pre>
        * Deprecated: Prefer to use `params` instead.
-       * tally_params defines all the paramaters of related to tally.
+       * tally_params defines all the parameters of related to tally.
        * </pre>
        *
        * <code>.cosmos.gov.v1.TallyParams tally_params = 7 [json_name = "tallyParams", deprecated = true];</code>
@@ -2814,7 +2814,7 @@ public final class GenesisProto {
       /**
        * <pre>
        * Deprecated: Prefer to use `params` instead.
-       * tally_params defines all the paramaters of related to tally.
+       * tally_params defines all the parameters of related to tally.
        * </pre>
        *
        * <code>.cosmos.gov.v1.TallyParams tally_params = 7 [json_name = "tallyParams", deprecated = true];</code>
@@ -2832,7 +2832,7 @@ public final class GenesisProto {
       /**
        * <pre>
        * Deprecated: Prefer to use `params` instead.
-       * tally_params defines all the paramaters of related to tally.
+       * tally_params defines all the parameters of related to tally.
        * </pre>
        *
        * <code>.cosmos.gov.v1.TallyParams tally_params = 7 [json_name = "tallyParams", deprecated = true];</code>
@@ -2845,7 +2845,7 @@ public final class GenesisProto {
       /**
        * <pre>
        * Deprecated: Prefer to use `params` instead.
-       * tally_params defines all the paramaters of related to tally.
+       * tally_params defines all the parameters of related to tally.
        * </pre>
        *
        * <code>.cosmos.gov.v1.TallyParams tally_params = 7 [json_name = "tallyParams", deprecated = true];</code>
@@ -2861,7 +2861,7 @@ public final class GenesisProto {
       /**
        * <pre>
        * Deprecated: Prefer to use `params` instead.
-       * tally_params defines all the paramaters of related to tally.
+       * tally_params defines all the parameters of related to tally.
        * </pre>
        *
        * <code>.cosmos.gov.v1.TallyParams tally_params = 7 [json_name = "tallyParams", deprecated = true];</code>
@@ -2885,7 +2885,7 @@ public final class GenesisProto {
           com.cosmos.gov.v1.GovProto.Params, com.cosmos.gov.v1.GovProto.Params.Builder, com.cosmos.gov.v1.GovProto.ParamsOrBuilder> paramsBuilder_;
       /**
        * <pre>
-       * params defines all the paramaters of x/gov module.
+       * params defines all the parameters of x/gov module.
        *
        * Since: cosmos-sdk 0.47
        * </pre>
@@ -2898,7 +2898,7 @@ public final class GenesisProto {
       }
       /**
        * <pre>
-       * params defines all the paramaters of x/gov module.
+       * params defines all the parameters of x/gov module.
        *
        * Since: cosmos-sdk 0.47
        * </pre>
@@ -2915,7 +2915,7 @@ public final class GenesisProto {
       }
       /**
        * <pre>
-       * params defines all the paramaters of x/gov module.
+       * params defines all the parameters of x/gov module.
        *
        * Since: cosmos-sdk 0.47
        * </pre>
@@ -2937,7 +2937,7 @@ public final class GenesisProto {
       }
       /**
        * <pre>
-       * params defines all the paramaters of x/gov module.
+       * params defines all the parameters of x/gov module.
        *
        * Since: cosmos-sdk 0.47
        * </pre>
@@ -2957,7 +2957,7 @@ public final class GenesisProto {
       }
       /**
        * <pre>
-       * params defines all the paramaters of x/gov module.
+       * params defines all the parameters of x/gov module.
        *
        * Since: cosmos-sdk 0.47
        * </pre>
@@ -2982,7 +2982,7 @@ public final class GenesisProto {
       }
       /**
        * <pre>
-       * params defines all the paramaters of x/gov module.
+       * params defines all the parameters of x/gov module.
        *
        * Since: cosmos-sdk 0.47
        * </pre>
@@ -3001,7 +3001,7 @@ public final class GenesisProto {
       }
       /**
        * <pre>
-       * params defines all the paramaters of x/gov module.
+       * params defines all the parameters of x/gov module.
        *
        * Since: cosmos-sdk 0.47
        * </pre>
@@ -3015,7 +3015,7 @@ public final class GenesisProto {
       }
       /**
        * <pre>
-       * params defines all the paramaters of x/gov module.
+       * params defines all the parameters of x/gov module.
        *
        * Since: cosmos-sdk 0.47
        * </pre>
@@ -3032,7 +3032,7 @@ public final class GenesisProto {
       }
       /**
        * <pre>
-       * params defines all the paramaters of x/gov module.
+       * params defines all the parameters of x/gov module.
        *
        * Since: cosmos-sdk 0.47
        * </pre>

--- a/proto/src/main/java/com/cosmos/gov/v1/QueryProto.java
+++ b/proto/src/main/java/com/cosmos/gov/v1/QueryProto.java
@@ -7513,7 +7513,7 @@ public final class QueryProto {
 
     /**
      * <pre>
-     * params defines all the paramaters of x/gov module.
+     * params defines all the parameters of x/gov module.
      *
      * Since: cosmos-sdk 0.47
      * </pre>
@@ -7524,7 +7524,7 @@ public final class QueryProto {
     boolean hasParams();
     /**
      * <pre>
-     * params defines all the paramaters of x/gov module.
+     * params defines all the parameters of x/gov module.
      *
      * Since: cosmos-sdk 0.47
      * </pre>
@@ -7535,7 +7535,7 @@ public final class QueryProto {
     com.cosmos.gov.v1.GovProto.Params getParams();
     /**
      * <pre>
-     * params defines all the paramaters of x/gov module.
+     * params defines all the parameters of x/gov module.
      *
      * Since: cosmos-sdk 0.47
      * </pre>
@@ -7722,7 +7722,7 @@ public final class QueryProto {
     private com.cosmos.gov.v1.GovProto.Params params_;
     /**
      * <pre>
-     * params defines all the paramaters of x/gov module.
+     * params defines all the parameters of x/gov module.
      *
      * Since: cosmos-sdk 0.47
      * </pre>
@@ -7736,7 +7736,7 @@ public final class QueryProto {
     }
     /**
      * <pre>
-     * params defines all the paramaters of x/gov module.
+     * params defines all the parameters of x/gov module.
      *
      * Since: cosmos-sdk 0.47
      * </pre>
@@ -7750,7 +7750,7 @@ public final class QueryProto {
     }
     /**
      * <pre>
-     * params defines all the paramaters of x/gov module.
+     * params defines all the parameters of x/gov module.
      *
      * Since: cosmos-sdk 0.47
      * </pre>
@@ -8721,7 +8721,7 @@ public final class QueryProto {
           com.cosmos.gov.v1.GovProto.Params, com.cosmos.gov.v1.GovProto.Params.Builder, com.cosmos.gov.v1.GovProto.ParamsOrBuilder> paramsBuilder_;
       /**
        * <pre>
-       * params defines all the paramaters of x/gov module.
+       * params defines all the parameters of x/gov module.
        *
        * Since: cosmos-sdk 0.47
        * </pre>
@@ -8734,7 +8734,7 @@ public final class QueryProto {
       }
       /**
        * <pre>
-       * params defines all the paramaters of x/gov module.
+       * params defines all the parameters of x/gov module.
        *
        * Since: cosmos-sdk 0.47
        * </pre>
@@ -8751,7 +8751,7 @@ public final class QueryProto {
       }
       /**
        * <pre>
-       * params defines all the paramaters of x/gov module.
+       * params defines all the parameters of x/gov module.
        *
        * Since: cosmos-sdk 0.47
        * </pre>
@@ -8773,7 +8773,7 @@ public final class QueryProto {
       }
       /**
        * <pre>
-       * params defines all the paramaters of x/gov module.
+       * params defines all the parameters of x/gov module.
        *
        * Since: cosmos-sdk 0.47
        * </pre>
@@ -8793,7 +8793,7 @@ public final class QueryProto {
       }
       /**
        * <pre>
-       * params defines all the paramaters of x/gov module.
+       * params defines all the parameters of x/gov module.
        *
        * Since: cosmos-sdk 0.47
        * </pre>
@@ -8818,7 +8818,7 @@ public final class QueryProto {
       }
       /**
        * <pre>
-       * params defines all the paramaters of x/gov module.
+       * params defines all the parameters of x/gov module.
        *
        * Since: cosmos-sdk 0.47
        * </pre>
@@ -8837,7 +8837,7 @@ public final class QueryProto {
       }
       /**
        * <pre>
-       * params defines all the paramaters of x/gov module.
+       * params defines all the parameters of x/gov module.
        *
        * Since: cosmos-sdk 0.47
        * </pre>
@@ -8851,7 +8851,7 @@ public final class QueryProto {
       }
       /**
        * <pre>
-       * params defines all the paramaters of x/gov module.
+       * params defines all the parameters of x/gov module.
        *
        * Since: cosmos-sdk 0.47
        * </pre>
@@ -8868,7 +8868,7 @@ public final class QueryProto {
       }
       /**
        * <pre>
-       * params defines all the paramaters of x/gov module.
+       * params defines all the parameters of x/gov module.
        *
        * Since: cosmos-sdk 0.47
        * </pre>

--- a/proto/src/main/java/com/initia/distribution/v1/GenesisProto.java
+++ b/proto/src/main/java/com/initia/distribution/v1/GenesisProto.java
@@ -5833,7 +5833,7 @@ public final class GenesisProto {
 
     /**
      * <pre>
-     * params defines all the paramaters of the module.
+     * params defines all the parameters of the module.
      * </pre>
      *
      * <code>.initia.distribution.v1.Params params = 1 [json_name = "params", (.gogoproto.nullable) = false, (.gogoproto.moretags) = "yaml:&#92;"params&#92;""];</code>
@@ -5842,7 +5842,7 @@ public final class GenesisProto {
     boolean hasParams();
     /**
      * <pre>
-     * params defines all the paramaters of the module.
+     * params defines all the parameters of the module.
      * </pre>
      *
      * <code>.initia.distribution.v1.Params params = 1 [json_name = "params", (.gogoproto.nullable) = false, (.gogoproto.moretags) = "yaml:&#92;"params&#92;""];</code>
@@ -5851,7 +5851,7 @@ public final class GenesisProto {
     com.initia.distribution.v1.DistributionProto.Params getParams();
     /**
      * <pre>
-     * params defines all the paramaters of the module.
+     * params defines all the parameters of the module.
      * </pre>
      *
      * <code>.initia.distribution.v1.Params params = 1 [json_name = "params", (.gogoproto.nullable) = false, (.gogoproto.moretags) = "yaml:&#92;"params&#92;""];</code>
@@ -6264,7 +6264,7 @@ public final class GenesisProto {
     private com.initia.distribution.v1.DistributionProto.Params params_;
     /**
      * <pre>
-     * params defines all the paramaters of the module.
+     * params defines all the parameters of the module.
      * </pre>
      *
      * <code>.initia.distribution.v1.Params params = 1 [json_name = "params", (.gogoproto.nullable) = false, (.gogoproto.moretags) = "yaml:&#92;"params&#92;""];</code>
@@ -6276,7 +6276,7 @@ public final class GenesisProto {
     }
     /**
      * <pre>
-     * params defines all the paramaters of the module.
+     * params defines all the parameters of the module.
      * </pre>
      *
      * <code>.initia.distribution.v1.Params params = 1 [json_name = "params", (.gogoproto.nullable) = false, (.gogoproto.moretags) = "yaml:&#92;"params&#92;""];</code>
@@ -6288,7 +6288,7 @@ public final class GenesisProto {
     }
     /**
      * <pre>
-     * params defines all the paramaters of the module.
+     * params defines all the parameters of the module.
      * </pre>
      *
      * <code>.initia.distribution.v1.Params params = 1 [json_name = "params", (.gogoproto.nullable) = false, (.gogoproto.moretags) = "yaml:&#92;"params&#92;""];</code>
@@ -7697,7 +7697,7 @@ public final class GenesisProto {
           com.initia.distribution.v1.DistributionProto.Params, com.initia.distribution.v1.DistributionProto.Params.Builder, com.initia.distribution.v1.DistributionProto.ParamsOrBuilder> paramsBuilder_;
       /**
        * <pre>
-       * params defines all the paramaters of the module.
+       * params defines all the parameters of the module.
        * </pre>
        *
        * <code>.initia.distribution.v1.Params params = 1 [json_name = "params", (.gogoproto.nullable) = false, (.gogoproto.moretags) = "yaml:&#92;"params&#92;""];</code>
@@ -7708,7 +7708,7 @@ public final class GenesisProto {
       }
       /**
        * <pre>
-       * params defines all the paramaters of the module.
+       * params defines all the parameters of the module.
        * </pre>
        *
        * <code>.initia.distribution.v1.Params params = 1 [json_name = "params", (.gogoproto.nullable) = false, (.gogoproto.moretags) = "yaml:&#92;"params&#92;""];</code>
@@ -7723,7 +7723,7 @@ public final class GenesisProto {
       }
       /**
        * <pre>
-       * params defines all the paramaters of the module.
+       * params defines all the parameters of the module.
        * </pre>
        *
        * <code>.initia.distribution.v1.Params params = 1 [json_name = "params", (.gogoproto.nullable) = false, (.gogoproto.moretags) = "yaml:&#92;"params&#92;""];</code>
@@ -7743,7 +7743,7 @@ public final class GenesisProto {
       }
       /**
        * <pre>
-       * params defines all the paramaters of the module.
+       * params defines all the parameters of the module.
        * </pre>
        *
        * <code>.initia.distribution.v1.Params params = 1 [json_name = "params", (.gogoproto.nullable) = false, (.gogoproto.moretags) = "yaml:&#92;"params&#92;""];</code>
@@ -7761,7 +7761,7 @@ public final class GenesisProto {
       }
       /**
        * <pre>
-       * params defines all the paramaters of the module.
+       * params defines all the parameters of the module.
        * </pre>
        *
        * <code>.initia.distribution.v1.Params params = 1 [json_name = "params", (.gogoproto.nullable) = false, (.gogoproto.moretags) = "yaml:&#92;"params&#92;""];</code>
@@ -7784,7 +7784,7 @@ public final class GenesisProto {
       }
       /**
        * <pre>
-       * params defines all the paramaters of the module.
+       * params defines all the parameters of the module.
        * </pre>
        *
        * <code>.initia.distribution.v1.Params params = 1 [json_name = "params", (.gogoproto.nullable) = false, (.gogoproto.moretags) = "yaml:&#92;"params&#92;""];</code>
@@ -7801,7 +7801,7 @@ public final class GenesisProto {
       }
       /**
        * <pre>
-       * params defines all the paramaters of the module.
+       * params defines all the parameters of the module.
        * </pre>
        *
        * <code>.initia.distribution.v1.Params params = 1 [json_name = "params", (.gogoproto.nullable) = false, (.gogoproto.moretags) = "yaml:&#92;"params&#92;""];</code>
@@ -7813,7 +7813,7 @@ public final class GenesisProto {
       }
       /**
        * <pre>
-       * params defines all the paramaters of the module.
+       * params defines all the parameters of the module.
        * </pre>
        *
        * <code>.initia.distribution.v1.Params params = 1 [json_name = "params", (.gogoproto.nullable) = false, (.gogoproto.moretags) = "yaml:&#92;"params&#92;""];</code>
@@ -7828,7 +7828,7 @@ public final class GenesisProto {
       }
       /**
        * <pre>
-       * params defines all the paramaters of the module.
+       * params defines all the parameters of the module.
        * </pre>
        *
        * <code>.initia.distribution.v1.Params params = 1 [json_name = "params", (.gogoproto.nullable) = false, (.gogoproto.moretags) = "yaml:&#92;"params&#92;""];</code>

--- a/proto/src/main/java/com/initia/gov/v1/GenesisProto.java
+++ b/proto/src/main/java/com/initia/gov/v1/GenesisProto.java
@@ -162,7 +162,7 @@ public final class GenesisProto {
 
     /**
      * <pre>
-     * params defines all the paramaters of x/gov module.
+     * params defines all the parameters of x/gov module.
      * </pre>
      *
      * <code>.initia.gov.v1.Params params = 5 [json_name = "params"];</code>
@@ -171,7 +171,7 @@ public final class GenesisProto {
     boolean hasParams();
     /**
      * <pre>
-     * params defines all the paramaters of x/gov module.
+     * params defines all the parameters of x/gov module.
      * </pre>
      *
      * <code>.initia.gov.v1.Params params = 5 [json_name = "params"];</code>
@@ -180,7 +180,7 @@ public final class GenesisProto {
     com.initia.gov.v1.GovProto.Params getParams();
     /**
      * <pre>
-     * params defines all the paramaters of x/gov module.
+     * params defines all the parameters of x/gov module.
      * </pre>
      *
      * <code>.initia.gov.v1.Params params = 5 [json_name = "params"];</code>
@@ -462,7 +462,7 @@ public final class GenesisProto {
     private com.initia.gov.v1.GovProto.Params params_;
     /**
      * <pre>
-     * params defines all the paramaters of x/gov module.
+     * params defines all the parameters of x/gov module.
      * </pre>
      *
      * <code>.initia.gov.v1.Params params = 5 [json_name = "params"];</code>
@@ -474,7 +474,7 @@ public final class GenesisProto {
     }
     /**
      * <pre>
-     * params defines all the paramaters of x/gov module.
+     * params defines all the parameters of x/gov module.
      * </pre>
      *
      * <code>.initia.gov.v1.Params params = 5 [json_name = "params"];</code>
@@ -486,7 +486,7 @@ public final class GenesisProto {
     }
     /**
      * <pre>
-     * params defines all the paramaters of x/gov module.
+     * params defines all the parameters of x/gov module.
      * </pre>
      *
      * <code>.initia.gov.v1.Params params = 5 [json_name = "params"];</code>
@@ -2136,7 +2136,7 @@ public final class GenesisProto {
           com.initia.gov.v1.GovProto.Params, com.initia.gov.v1.GovProto.Params.Builder, com.initia.gov.v1.GovProto.ParamsOrBuilder> paramsBuilder_;
       /**
        * <pre>
-       * params defines all the paramaters of x/gov module.
+       * params defines all the parameters of x/gov module.
        * </pre>
        *
        * <code>.initia.gov.v1.Params params = 5 [json_name = "params"];</code>
@@ -2147,7 +2147,7 @@ public final class GenesisProto {
       }
       /**
        * <pre>
-       * params defines all the paramaters of x/gov module.
+       * params defines all the parameters of x/gov module.
        * </pre>
        *
        * <code>.initia.gov.v1.Params params = 5 [json_name = "params"];</code>
@@ -2162,7 +2162,7 @@ public final class GenesisProto {
       }
       /**
        * <pre>
-       * params defines all the paramaters of x/gov module.
+       * params defines all the parameters of x/gov module.
        * </pre>
        *
        * <code>.initia.gov.v1.Params params = 5 [json_name = "params"];</code>
@@ -2182,7 +2182,7 @@ public final class GenesisProto {
       }
       /**
        * <pre>
-       * params defines all the paramaters of x/gov module.
+       * params defines all the parameters of x/gov module.
        * </pre>
        *
        * <code>.initia.gov.v1.Params params = 5 [json_name = "params"];</code>
@@ -2200,7 +2200,7 @@ public final class GenesisProto {
       }
       /**
        * <pre>
-       * params defines all the paramaters of x/gov module.
+       * params defines all the parameters of x/gov module.
        * </pre>
        *
        * <code>.initia.gov.v1.Params params = 5 [json_name = "params"];</code>
@@ -2223,7 +2223,7 @@ public final class GenesisProto {
       }
       /**
        * <pre>
-       * params defines all the paramaters of x/gov module.
+       * params defines all the parameters of x/gov module.
        * </pre>
        *
        * <code>.initia.gov.v1.Params params = 5 [json_name = "params"];</code>
@@ -2240,7 +2240,7 @@ public final class GenesisProto {
       }
       /**
        * <pre>
-       * params defines all the paramaters of x/gov module.
+       * params defines all the parameters of x/gov module.
        * </pre>
        *
        * <code>.initia.gov.v1.Params params = 5 [json_name = "params"];</code>
@@ -2252,7 +2252,7 @@ public final class GenesisProto {
       }
       /**
        * <pre>
-       * params defines all the paramaters of x/gov module.
+       * params defines all the parameters of x/gov module.
        * </pre>
        *
        * <code>.initia.gov.v1.Params params = 5 [json_name = "params"];</code>
@@ -2267,7 +2267,7 @@ public final class GenesisProto {
       }
       /**
        * <pre>
-       * params defines all the paramaters of x/gov module.
+       * params defines all the parameters of x/gov module.
        * </pre>
        *
        * <code>.initia.gov.v1.Params params = 5 [json_name = "params"];</code>

--- a/proto/src/main/java/com/initia/mstaking/v1/GenesisProto.java
+++ b/proto/src/main/java/com/initia/mstaking/v1/GenesisProto.java
@@ -20,7 +20,7 @@ public final class GenesisProto {
 
     /**
      * <pre>
-     * params defines all the paramaters of related to deposit.
+     * params defines all the parameters of related to deposit.
      * </pre>
      *
      * <code>.initia.mstaking.v1.Params params = 1 [json_name = "params", (.gogoproto.nullable) = false, (.amino.dont_omitempty) = true];</code>
@@ -29,7 +29,7 @@ public final class GenesisProto {
     boolean hasParams();
     /**
      * <pre>
-     * params defines all the paramaters of related to deposit.
+     * params defines all the parameters of related to deposit.
      * </pre>
      *
      * <code>.initia.mstaking.v1.Params params = 1 [json_name = "params", (.gogoproto.nullable) = false, (.amino.dont_omitempty) = true];</code>
@@ -38,7 +38,7 @@ public final class GenesisProto {
     com.initia.mstaking.v1.StakingProto.Params getParams();
     /**
      * <pre>
-     * params defines all the paramaters of related to deposit.
+     * params defines all the parameters of related to deposit.
      * </pre>
      *
      * <code>.initia.mstaking.v1.Params params = 1 [json_name = "params", (.gogoproto.nullable) = false, (.amino.dont_omitempty) = true];</code>
@@ -334,7 +334,7 @@ public final class GenesisProto {
     private com.initia.mstaking.v1.StakingProto.Params params_;
     /**
      * <pre>
-     * params defines all the paramaters of related to deposit.
+     * params defines all the parameters of related to deposit.
      * </pre>
      *
      * <code>.initia.mstaking.v1.Params params = 1 [json_name = "params", (.gogoproto.nullable) = false, (.amino.dont_omitempty) = true];</code>
@@ -346,7 +346,7 @@ public final class GenesisProto {
     }
     /**
      * <pre>
-     * params defines all the paramaters of related to deposit.
+     * params defines all the parameters of related to deposit.
      * </pre>
      *
      * <code>.initia.mstaking.v1.Params params = 1 [json_name = "params", (.gogoproto.nullable) = false, (.amino.dont_omitempty) = true];</code>
@@ -358,7 +358,7 @@ public final class GenesisProto {
     }
     /**
      * <pre>
-     * params defines all the paramaters of related to deposit.
+     * params defines all the parameters of related to deposit.
      * </pre>
      *
      * <code>.initia.mstaking.v1.Params params = 1 [json_name = "params", (.gogoproto.nullable) = false, (.amino.dont_omitempty) = true];</code>
@@ -1443,7 +1443,7 @@ public final class GenesisProto {
           com.initia.mstaking.v1.StakingProto.Params, com.initia.mstaking.v1.StakingProto.Params.Builder, com.initia.mstaking.v1.StakingProto.ParamsOrBuilder> paramsBuilder_;
       /**
        * <pre>
-       * params defines all the paramaters of related to deposit.
+       * params defines all the parameters of related to deposit.
        * </pre>
        *
        * <code>.initia.mstaking.v1.Params params = 1 [json_name = "params", (.gogoproto.nullable) = false, (.amino.dont_omitempty) = true];</code>
@@ -1454,7 +1454,7 @@ public final class GenesisProto {
       }
       /**
        * <pre>
-       * params defines all the paramaters of related to deposit.
+       * params defines all the parameters of related to deposit.
        * </pre>
        *
        * <code>.initia.mstaking.v1.Params params = 1 [json_name = "params", (.gogoproto.nullable) = false, (.amino.dont_omitempty) = true];</code>
@@ -1469,7 +1469,7 @@ public final class GenesisProto {
       }
       /**
        * <pre>
-       * params defines all the paramaters of related to deposit.
+       * params defines all the parameters of related to deposit.
        * </pre>
        *
        * <code>.initia.mstaking.v1.Params params = 1 [json_name = "params", (.gogoproto.nullable) = false, (.amino.dont_omitempty) = true];</code>
@@ -1489,7 +1489,7 @@ public final class GenesisProto {
       }
       /**
        * <pre>
-       * params defines all the paramaters of related to deposit.
+       * params defines all the parameters of related to deposit.
        * </pre>
        *
        * <code>.initia.mstaking.v1.Params params = 1 [json_name = "params", (.gogoproto.nullable) = false, (.amino.dont_omitempty) = true];</code>
@@ -1507,7 +1507,7 @@ public final class GenesisProto {
       }
       /**
        * <pre>
-       * params defines all the paramaters of related to deposit.
+       * params defines all the parameters of related to deposit.
        * </pre>
        *
        * <code>.initia.mstaking.v1.Params params = 1 [json_name = "params", (.gogoproto.nullable) = false, (.amino.dont_omitempty) = true];</code>
@@ -1530,7 +1530,7 @@ public final class GenesisProto {
       }
       /**
        * <pre>
-       * params defines all the paramaters of related to deposit.
+       * params defines all the parameters of related to deposit.
        * </pre>
        *
        * <code>.initia.mstaking.v1.Params params = 1 [json_name = "params", (.gogoproto.nullable) = false, (.amino.dont_omitempty) = true];</code>
@@ -1547,7 +1547,7 @@ public final class GenesisProto {
       }
       /**
        * <pre>
-       * params defines all the paramaters of related to deposit.
+       * params defines all the parameters of related to deposit.
        * </pre>
        *
        * <code>.initia.mstaking.v1.Params params = 1 [json_name = "params", (.gogoproto.nullable) = false, (.amino.dont_omitempty) = true];</code>
@@ -1559,7 +1559,7 @@ public final class GenesisProto {
       }
       /**
        * <pre>
-       * params defines all the paramaters of related to deposit.
+       * params defines all the parameters of related to deposit.
        * </pre>
        *
        * <code>.initia.mstaking.v1.Params params = 1 [json_name = "params", (.gogoproto.nullable) = false, (.amino.dont_omitempty) = true];</code>
@@ -1574,7 +1574,7 @@ public final class GenesisProto {
       }
       /**
        * <pre>
-       * params defines all the paramaters of related to deposit.
+       * params defines all the parameters of related to deposit.
        * </pre>
        *
        * <code>.initia.mstaking.v1.Params params = 1 [json_name = "params", (.gogoproto.nullable) = false, (.amino.dont_omitempty) = true];</code>

--- a/proto/src/main/java/com/initia/reward/v1/GenesisProto.java
+++ b/proto/src/main/java/com/initia/reward/v1/GenesisProto.java
@@ -20,7 +20,7 @@ public final class GenesisProto {
 
     /**
      * <pre>
-     * Params defines all the paramaters of the module.
+     * Params defines all the parameters of the module.
      * </pre>
      *
      * <code>.initia.reward.v1.Params params = 1 [json_name = "params", (.gogoproto.nullable) = false];</code>
@@ -29,7 +29,7 @@ public final class GenesisProto {
     boolean hasParams();
     /**
      * <pre>
-     * Params defines all the paramaters of the module.
+     * Params defines all the parameters of the module.
      * </pre>
      *
      * <code>.initia.reward.v1.Params params = 1 [json_name = "params", (.gogoproto.nullable) = false];</code>
@@ -38,7 +38,7 @@ public final class GenesisProto {
     com.initia.reward.v1.TypesProto.Params getParams();
     /**
      * <pre>
-     * Params defines all the paramaters of the module.
+     * Params defines all the parameters of the module.
      * </pre>
      *
      * <code>.initia.reward.v1.Params params = 1 [json_name = "params", (.gogoproto.nullable) = false];</code>
@@ -118,7 +118,7 @@ public final class GenesisProto {
     private com.initia.reward.v1.TypesProto.Params params_;
     /**
      * <pre>
-     * Params defines all the paramaters of the module.
+     * Params defines all the parameters of the module.
      * </pre>
      *
      * <code>.initia.reward.v1.Params params = 1 [json_name = "params", (.gogoproto.nullable) = false];</code>
@@ -130,7 +130,7 @@ public final class GenesisProto {
     }
     /**
      * <pre>
-     * Params defines all the paramaters of the module.
+     * Params defines all the parameters of the module.
      * </pre>
      *
      * <code>.initia.reward.v1.Params params = 1 [json_name = "params", (.gogoproto.nullable) = false];</code>
@@ -142,7 +142,7 @@ public final class GenesisProto {
     }
     /**
      * <pre>
-     * Params defines all the paramaters of the module.
+     * Params defines all the parameters of the module.
      * </pre>
      *
      * <code>.initia.reward.v1.Params params = 1 [json_name = "params", (.gogoproto.nullable) = false];</code>
@@ -623,7 +623,7 @@ public final class GenesisProto {
           com.initia.reward.v1.TypesProto.Params, com.initia.reward.v1.TypesProto.Params.Builder, com.initia.reward.v1.TypesProto.ParamsOrBuilder> paramsBuilder_;
       /**
        * <pre>
-       * Params defines all the paramaters of the module.
+       * Params defines all the parameters of the module.
        * </pre>
        *
        * <code>.initia.reward.v1.Params params = 1 [json_name = "params", (.gogoproto.nullable) = false];</code>
@@ -634,7 +634,7 @@ public final class GenesisProto {
       }
       /**
        * <pre>
-       * Params defines all the paramaters of the module.
+       * Params defines all the parameters of the module.
        * </pre>
        *
        * <code>.initia.reward.v1.Params params = 1 [json_name = "params", (.gogoproto.nullable) = false];</code>
@@ -649,7 +649,7 @@ public final class GenesisProto {
       }
       /**
        * <pre>
-       * Params defines all the paramaters of the module.
+       * Params defines all the parameters of the module.
        * </pre>
        *
        * <code>.initia.reward.v1.Params params = 1 [json_name = "params", (.gogoproto.nullable) = false];</code>
@@ -669,7 +669,7 @@ public final class GenesisProto {
       }
       /**
        * <pre>
-       * Params defines all the paramaters of the module.
+       * Params defines all the parameters of the module.
        * </pre>
        *
        * <code>.initia.reward.v1.Params params = 1 [json_name = "params", (.gogoproto.nullable) = false];</code>
@@ -687,7 +687,7 @@ public final class GenesisProto {
       }
       /**
        * <pre>
-       * Params defines all the paramaters of the module.
+       * Params defines all the parameters of the module.
        * </pre>
        *
        * <code>.initia.reward.v1.Params params = 1 [json_name = "params", (.gogoproto.nullable) = false];</code>
@@ -710,7 +710,7 @@ public final class GenesisProto {
       }
       /**
        * <pre>
-       * Params defines all the paramaters of the module.
+       * Params defines all the parameters of the module.
        * </pre>
        *
        * <code>.initia.reward.v1.Params params = 1 [json_name = "params", (.gogoproto.nullable) = false];</code>
@@ -727,7 +727,7 @@ public final class GenesisProto {
       }
       /**
        * <pre>
-       * Params defines all the paramaters of the module.
+       * Params defines all the parameters of the module.
        * </pre>
        *
        * <code>.initia.reward.v1.Params params = 1 [json_name = "params", (.gogoproto.nullable) = false];</code>
@@ -739,7 +739,7 @@ public final class GenesisProto {
       }
       /**
        * <pre>
-       * Params defines all the paramaters of the module.
+       * Params defines all the parameters of the module.
        * </pre>
        *
        * <code>.initia.reward.v1.Params params = 1 [json_name = "params", (.gogoproto.nullable) = false];</code>
@@ -754,7 +754,7 @@ public final class GenesisProto {
       }
       /**
        * <pre>
-       * Params defines all the paramaters of the module.
+       * Params defines all the parameters of the module.
        * </pre>
        *
        * <code>.initia.reward.v1.Params params = 1 [json_name = "params", (.gogoproto.nullable) = false];</code>

--- a/proto/src/main/java/com/kava/cdp/v1beta1/GenesisProto.java
+++ b/proto/src/main/java/com/kava/cdp/v1beta1/GenesisProto.java
@@ -20,7 +20,7 @@ public final class GenesisProto {
 
     /**
      * <pre>
-     * params defines all the paramaters of the module.
+     * params defines all the parameters of the module.
      * </pre>
      *
      * <code>.kava.cdp.v1beta1.Params params = 1 [json_name = "params", (.gogoproto.nullable) = false];</code>
@@ -29,7 +29,7 @@ public final class GenesisProto {
     boolean hasParams();
     /**
      * <pre>
-     * params defines all the paramaters of the module.
+     * params defines all the parameters of the module.
      * </pre>
      *
      * <code>.kava.cdp.v1beta1.Params params = 1 [json_name = "params", (.gogoproto.nullable) = false];</code>
@@ -38,7 +38,7 @@ public final class GenesisProto {
     com.kava.cdp.v1beta1.GenesisProto.Params getParams();
     /**
      * <pre>
-     * params defines all the paramaters of the module.
+     * params defines all the parameters of the module.
      * </pre>
      *
      * <code>.kava.cdp.v1beta1.Params params = 1 [json_name = "params", (.gogoproto.nullable) = false];</code>
@@ -220,7 +220,7 @@ public final class GenesisProto {
     private com.kava.cdp.v1beta1.GenesisProto.Params params_;
     /**
      * <pre>
-     * params defines all the paramaters of the module.
+     * params defines all the parameters of the module.
      * </pre>
      *
      * <code>.kava.cdp.v1beta1.Params params = 1 [json_name = "params", (.gogoproto.nullable) = false];</code>
@@ -232,7 +232,7 @@ public final class GenesisProto {
     }
     /**
      * <pre>
-     * params defines all the paramaters of the module.
+     * params defines all the parameters of the module.
      * </pre>
      *
      * <code>.kava.cdp.v1beta1.Params params = 1 [json_name = "params", (.gogoproto.nullable) = false];</code>
@@ -244,7 +244,7 @@ public final class GenesisProto {
     }
     /**
      * <pre>
-     * params defines all the paramaters of the module.
+     * params defines all the parameters of the module.
      * </pre>
      *
      * <code>.kava.cdp.v1beta1.Params params = 1 [json_name = "params", (.gogoproto.nullable) = false];</code>
@@ -1202,7 +1202,7 @@ public final class GenesisProto {
           com.kava.cdp.v1beta1.GenesisProto.Params, com.kava.cdp.v1beta1.GenesisProto.Params.Builder, com.kava.cdp.v1beta1.GenesisProto.ParamsOrBuilder> paramsBuilder_;
       /**
        * <pre>
-       * params defines all the paramaters of the module.
+       * params defines all the parameters of the module.
        * </pre>
        *
        * <code>.kava.cdp.v1beta1.Params params = 1 [json_name = "params", (.gogoproto.nullable) = false];</code>
@@ -1213,7 +1213,7 @@ public final class GenesisProto {
       }
       /**
        * <pre>
-       * params defines all the paramaters of the module.
+       * params defines all the parameters of the module.
        * </pre>
        *
        * <code>.kava.cdp.v1beta1.Params params = 1 [json_name = "params", (.gogoproto.nullable) = false];</code>
@@ -1228,7 +1228,7 @@ public final class GenesisProto {
       }
       /**
        * <pre>
-       * params defines all the paramaters of the module.
+       * params defines all the parameters of the module.
        * </pre>
        *
        * <code>.kava.cdp.v1beta1.Params params = 1 [json_name = "params", (.gogoproto.nullable) = false];</code>
@@ -1248,7 +1248,7 @@ public final class GenesisProto {
       }
       /**
        * <pre>
-       * params defines all the paramaters of the module.
+       * params defines all the parameters of the module.
        * </pre>
        *
        * <code>.kava.cdp.v1beta1.Params params = 1 [json_name = "params", (.gogoproto.nullable) = false];</code>
@@ -1266,7 +1266,7 @@ public final class GenesisProto {
       }
       /**
        * <pre>
-       * params defines all the paramaters of the module.
+       * params defines all the parameters of the module.
        * </pre>
        *
        * <code>.kava.cdp.v1beta1.Params params = 1 [json_name = "params", (.gogoproto.nullable) = false];</code>
@@ -1289,7 +1289,7 @@ public final class GenesisProto {
       }
       /**
        * <pre>
-       * params defines all the paramaters of the module.
+       * params defines all the parameters of the module.
        * </pre>
        *
        * <code>.kava.cdp.v1beta1.Params params = 1 [json_name = "params", (.gogoproto.nullable) = false];</code>
@@ -1306,7 +1306,7 @@ public final class GenesisProto {
       }
       /**
        * <pre>
-       * params defines all the paramaters of the module.
+       * params defines all the parameters of the module.
        * </pre>
        *
        * <code>.kava.cdp.v1beta1.Params params = 1 [json_name = "params", (.gogoproto.nullable) = false];</code>
@@ -1318,7 +1318,7 @@ public final class GenesisProto {
       }
       /**
        * <pre>
-       * params defines all the paramaters of the module.
+       * params defines all the parameters of the module.
        * </pre>
        *
        * <code>.kava.cdp.v1beta1.Params params = 1 [json_name = "params", (.gogoproto.nullable) = false];</code>
@@ -1333,7 +1333,7 @@ public final class GenesisProto {
       }
       /**
        * <pre>
-       * params defines all the paramaters of the module.
+       * params defines all the parameters of the module.
        * </pre>
        *
        * <code>.kava.cdp.v1beta1.Params params = 1 [json_name = "params", (.gogoproto.nullable) = false];</code>

--- a/proto/src/main/java/com/kava/earn/v1beta1/GenesisProto.java
+++ b/proto/src/main/java/com/kava/earn/v1beta1/GenesisProto.java
@@ -20,7 +20,7 @@ public final class GenesisProto {
 
     /**
      * <pre>
-     * params defines all the paramaters related to earn
+     * params defines all the parameters related to earn
      * </pre>
      *
      * <code>.kava.earn.v1beta1.Params params = 1 [json_name = "params", (.gogoproto.nullable) = false];</code>
@@ -29,7 +29,7 @@ public final class GenesisProto {
     boolean hasParams();
     /**
      * <pre>
-     * params defines all the paramaters related to earn
+     * params defines all the parameters related to earn
      * </pre>
      *
      * <code>.kava.earn.v1beta1.Params params = 1 [json_name = "params", (.gogoproto.nullable) = false];</code>
@@ -38,7 +38,7 @@ public final class GenesisProto {
     com.kava.earn.v1beta1.ParamsProto.Params getParams();
     /**
      * <pre>
-     * params defines all the paramaters related to earn
+     * params defines all the parameters related to earn
      * </pre>
      *
      * <code>.kava.earn.v1beta1.Params params = 1 [json_name = "params", (.gogoproto.nullable) = false];</code>
@@ -178,7 +178,7 @@ public final class GenesisProto {
     private com.kava.earn.v1beta1.ParamsProto.Params params_;
     /**
      * <pre>
-     * params defines all the paramaters related to earn
+     * params defines all the parameters related to earn
      * </pre>
      *
      * <code>.kava.earn.v1beta1.Params params = 1 [json_name = "params", (.gogoproto.nullable) = false];</code>
@@ -190,7 +190,7 @@ public final class GenesisProto {
     }
     /**
      * <pre>
-     * params defines all the paramaters related to earn
+     * params defines all the parameters related to earn
      * </pre>
      *
      * <code>.kava.earn.v1beta1.Params params = 1 [json_name = "params", (.gogoproto.nullable) = false];</code>
@@ -202,7 +202,7 @@ public final class GenesisProto {
     }
     /**
      * <pre>
-     * params defines all the paramaters related to earn
+     * params defines all the parameters related to earn
      * </pre>
      *
      * <code>.kava.earn.v1beta1.Params params = 1 [json_name = "params", (.gogoproto.nullable) = false];</code>
@@ -821,7 +821,7 @@ public final class GenesisProto {
           com.kava.earn.v1beta1.ParamsProto.Params, com.kava.earn.v1beta1.ParamsProto.Params.Builder, com.kava.earn.v1beta1.ParamsProto.ParamsOrBuilder> paramsBuilder_;
       /**
        * <pre>
-       * params defines all the paramaters related to earn
+       * params defines all the parameters related to earn
        * </pre>
        *
        * <code>.kava.earn.v1beta1.Params params = 1 [json_name = "params", (.gogoproto.nullable) = false];</code>
@@ -832,7 +832,7 @@ public final class GenesisProto {
       }
       /**
        * <pre>
-       * params defines all the paramaters related to earn
+       * params defines all the parameters related to earn
        * </pre>
        *
        * <code>.kava.earn.v1beta1.Params params = 1 [json_name = "params", (.gogoproto.nullable) = false];</code>
@@ -847,7 +847,7 @@ public final class GenesisProto {
       }
       /**
        * <pre>
-       * params defines all the paramaters related to earn
+       * params defines all the parameters related to earn
        * </pre>
        *
        * <code>.kava.earn.v1beta1.Params params = 1 [json_name = "params", (.gogoproto.nullable) = false];</code>
@@ -867,7 +867,7 @@ public final class GenesisProto {
       }
       /**
        * <pre>
-       * params defines all the paramaters related to earn
+       * params defines all the parameters related to earn
        * </pre>
        *
        * <code>.kava.earn.v1beta1.Params params = 1 [json_name = "params", (.gogoproto.nullable) = false];</code>
@@ -885,7 +885,7 @@ public final class GenesisProto {
       }
       /**
        * <pre>
-       * params defines all the paramaters related to earn
+       * params defines all the parameters related to earn
        * </pre>
        *
        * <code>.kava.earn.v1beta1.Params params = 1 [json_name = "params", (.gogoproto.nullable) = false];</code>
@@ -908,7 +908,7 @@ public final class GenesisProto {
       }
       /**
        * <pre>
-       * params defines all the paramaters related to earn
+       * params defines all the parameters related to earn
        * </pre>
        *
        * <code>.kava.earn.v1beta1.Params params = 1 [json_name = "params", (.gogoproto.nullable) = false];</code>
@@ -925,7 +925,7 @@ public final class GenesisProto {
       }
       /**
        * <pre>
-       * params defines all the paramaters related to earn
+       * params defines all the parameters related to earn
        * </pre>
        *
        * <code>.kava.earn.v1beta1.Params params = 1 [json_name = "params", (.gogoproto.nullable) = false];</code>
@@ -937,7 +937,7 @@ public final class GenesisProto {
       }
       /**
        * <pre>
-       * params defines all the paramaters related to earn
+       * params defines all the parameters related to earn
        * </pre>
        *
        * <code>.kava.earn.v1beta1.Params params = 1 [json_name = "params", (.gogoproto.nullable) = false];</code>
@@ -952,7 +952,7 @@ public final class GenesisProto {
       }
       /**
        * <pre>
-       * params defines all the paramaters related to earn
+       * params defines all the parameters related to earn
        * </pre>
        *
        * <code>.kava.earn.v1beta1.Params params = 1 [json_name = "params", (.gogoproto.nullable) = false];</code>

--- a/proto/src/main/java/com/kava/pricefeed/v1beta1/GenesisProto.java
+++ b/proto/src/main/java/com/kava/pricefeed/v1beta1/GenesisProto.java
@@ -20,7 +20,7 @@ public final class GenesisProto {
 
     /**
      * <pre>
-     * params defines all the paramaters of the module.
+     * params defines all the parameters of the module.
      * </pre>
      *
      * <code>.kava.pricefeed.v1beta1.Params params = 1 [json_name = "params", (.gogoproto.nullable) = false];</code>
@@ -29,7 +29,7 @@ public final class GenesisProto {
     boolean hasParams();
     /**
      * <pre>
-     * params defines all the paramaters of the module.
+     * params defines all the parameters of the module.
      * </pre>
      *
      * <code>.kava.pricefeed.v1beta1.Params params = 1 [json_name = "params", (.gogoproto.nullable) = false];</code>
@@ -38,7 +38,7 @@ public final class GenesisProto {
     com.kava.pricefeed.v1beta1.StoreProto.Params getParams();
     /**
      * <pre>
-     * params defines all the paramaters of the module.
+     * params defines all the parameters of the module.
      * </pre>
      *
      * <code>.kava.pricefeed.v1beta1.Params params = 1 [json_name = "params", (.gogoproto.nullable) = false];</code>
@@ -113,7 +113,7 @@ public final class GenesisProto {
     private com.kava.pricefeed.v1beta1.StoreProto.Params params_;
     /**
      * <pre>
-     * params defines all the paramaters of the module.
+     * params defines all the parameters of the module.
      * </pre>
      *
      * <code>.kava.pricefeed.v1beta1.Params params = 1 [json_name = "params", (.gogoproto.nullable) = false];</code>
@@ -125,7 +125,7 @@ public final class GenesisProto {
     }
     /**
      * <pre>
-     * params defines all the paramaters of the module.
+     * params defines all the parameters of the module.
      * </pre>
      *
      * <code>.kava.pricefeed.v1beta1.Params params = 1 [json_name = "params", (.gogoproto.nullable) = false];</code>
@@ -137,7 +137,7 @@ public final class GenesisProto {
     }
     /**
      * <pre>
-     * params defines all the paramaters of the module.
+     * params defines all the parameters of the module.
      * </pre>
      *
      * <code>.kava.pricefeed.v1beta1.Params params = 1 [json_name = "params", (.gogoproto.nullable) = false];</code>
@@ -607,7 +607,7 @@ public final class GenesisProto {
           com.kava.pricefeed.v1beta1.StoreProto.Params, com.kava.pricefeed.v1beta1.StoreProto.Params.Builder, com.kava.pricefeed.v1beta1.StoreProto.ParamsOrBuilder> paramsBuilder_;
       /**
        * <pre>
-       * params defines all the paramaters of the module.
+       * params defines all the parameters of the module.
        * </pre>
        *
        * <code>.kava.pricefeed.v1beta1.Params params = 1 [json_name = "params", (.gogoproto.nullable) = false];</code>
@@ -618,7 +618,7 @@ public final class GenesisProto {
       }
       /**
        * <pre>
-       * params defines all the paramaters of the module.
+       * params defines all the parameters of the module.
        * </pre>
        *
        * <code>.kava.pricefeed.v1beta1.Params params = 1 [json_name = "params", (.gogoproto.nullable) = false];</code>
@@ -633,7 +633,7 @@ public final class GenesisProto {
       }
       /**
        * <pre>
-       * params defines all the paramaters of the module.
+       * params defines all the parameters of the module.
        * </pre>
        *
        * <code>.kava.pricefeed.v1beta1.Params params = 1 [json_name = "params", (.gogoproto.nullable) = false];</code>
@@ -653,7 +653,7 @@ public final class GenesisProto {
       }
       /**
        * <pre>
-       * params defines all the paramaters of the module.
+       * params defines all the parameters of the module.
        * </pre>
        *
        * <code>.kava.pricefeed.v1beta1.Params params = 1 [json_name = "params", (.gogoproto.nullable) = false];</code>
@@ -671,7 +671,7 @@ public final class GenesisProto {
       }
       /**
        * <pre>
-       * params defines all the paramaters of the module.
+       * params defines all the parameters of the module.
        * </pre>
        *
        * <code>.kava.pricefeed.v1beta1.Params params = 1 [json_name = "params", (.gogoproto.nullable) = false];</code>
@@ -694,7 +694,7 @@ public final class GenesisProto {
       }
       /**
        * <pre>
-       * params defines all the paramaters of the module.
+       * params defines all the parameters of the module.
        * </pre>
        *
        * <code>.kava.pricefeed.v1beta1.Params params = 1 [json_name = "params", (.gogoproto.nullable) = false];</code>
@@ -711,7 +711,7 @@ public final class GenesisProto {
       }
       /**
        * <pre>
-       * params defines all the paramaters of the module.
+       * params defines all the parameters of the module.
        * </pre>
        *
        * <code>.kava.pricefeed.v1beta1.Params params = 1 [json_name = "params", (.gogoproto.nullable) = false];</code>
@@ -723,7 +723,7 @@ public final class GenesisProto {
       }
       /**
        * <pre>
-       * params defines all the paramaters of the module.
+       * params defines all the parameters of the module.
        * </pre>
        *
        * <code>.kava.pricefeed.v1beta1.Params params = 1 [json_name = "params", (.gogoproto.nullable) = false];</code>
@@ -738,7 +738,7 @@ public final class GenesisProto {
       }
       /**
        * <pre>
-       * params defines all the paramaters of the module.
+       * params defines all the parameters of the module.
        * </pre>
        *
        * <code>.kava.pricefeed.v1beta1.Params params = 1 [json_name = "params", (.gogoproto.nullable) = false];</code>

--- a/proto/src/main/java/com/kava/swap/v1beta1/GenesisProto.java
+++ b/proto/src/main/java/com/kava/swap/v1beta1/GenesisProto.java
@@ -20,7 +20,7 @@ public final class GenesisProto {
 
     /**
      * <pre>
-     * params defines all the paramaters related to swap
+     * params defines all the parameters related to swap
      * </pre>
      *
      * <code>.kava.swap.v1beta1.Params params = 1 [json_name = "params", (.gogoproto.nullable) = false];</code>
@@ -29,7 +29,7 @@ public final class GenesisProto {
     boolean hasParams();
     /**
      * <pre>
-     * params defines all the paramaters related to swap
+     * params defines all the parameters related to swap
      * </pre>
      *
      * <code>.kava.swap.v1beta1.Params params = 1 [json_name = "params", (.gogoproto.nullable) = false];</code>
@@ -38,7 +38,7 @@ public final class GenesisProto {
     com.kava.swap.v1beta1.SwapProto.Params getParams();
     /**
      * <pre>
-     * params defines all the paramaters related to swap
+     * params defines all the parameters related to swap
      * </pre>
      *
      * <code>.kava.swap.v1beta1.Params params = 1 [json_name = "params", (.gogoproto.nullable) = false];</code>
@@ -178,7 +178,7 @@ public final class GenesisProto {
     private com.kava.swap.v1beta1.SwapProto.Params params_;
     /**
      * <pre>
-     * params defines all the paramaters related to swap
+     * params defines all the parameters related to swap
      * </pre>
      *
      * <code>.kava.swap.v1beta1.Params params = 1 [json_name = "params", (.gogoproto.nullable) = false];</code>
@@ -190,7 +190,7 @@ public final class GenesisProto {
     }
     /**
      * <pre>
-     * params defines all the paramaters related to swap
+     * params defines all the parameters related to swap
      * </pre>
      *
      * <code>.kava.swap.v1beta1.Params params = 1 [json_name = "params", (.gogoproto.nullable) = false];</code>
@@ -202,7 +202,7 @@ public final class GenesisProto {
     }
     /**
      * <pre>
-     * params defines all the paramaters related to swap
+     * params defines all the parameters related to swap
      * </pre>
      *
      * <code>.kava.swap.v1beta1.Params params = 1 [json_name = "params", (.gogoproto.nullable) = false];</code>
@@ -821,7 +821,7 @@ public final class GenesisProto {
           com.kava.swap.v1beta1.SwapProto.Params, com.kava.swap.v1beta1.SwapProto.Params.Builder, com.kava.swap.v1beta1.SwapProto.ParamsOrBuilder> paramsBuilder_;
       /**
        * <pre>
-       * params defines all the paramaters related to swap
+       * params defines all the parameters related to swap
        * </pre>
        *
        * <code>.kava.swap.v1beta1.Params params = 1 [json_name = "params", (.gogoproto.nullable) = false];</code>
@@ -832,7 +832,7 @@ public final class GenesisProto {
       }
       /**
        * <pre>
-       * params defines all the paramaters related to swap
+       * params defines all the parameters related to swap
        * </pre>
        *
        * <code>.kava.swap.v1beta1.Params params = 1 [json_name = "params", (.gogoproto.nullable) = false];</code>
@@ -847,7 +847,7 @@ public final class GenesisProto {
       }
       /**
        * <pre>
-       * params defines all the paramaters related to swap
+       * params defines all the parameters related to swap
        * </pre>
        *
        * <code>.kava.swap.v1beta1.Params params = 1 [json_name = "params", (.gogoproto.nullable) = false];</code>
@@ -867,7 +867,7 @@ public final class GenesisProto {
       }
       /**
        * <pre>
-       * params defines all the paramaters related to swap
+       * params defines all the parameters related to swap
        * </pre>
        *
        * <code>.kava.swap.v1beta1.Params params = 1 [json_name = "params", (.gogoproto.nullable) = false];</code>
@@ -885,7 +885,7 @@ public final class GenesisProto {
       }
       /**
        * <pre>
-       * params defines all the paramaters related to swap
+       * params defines all the parameters related to swap
        * </pre>
        *
        * <code>.kava.swap.v1beta1.Params params = 1 [json_name = "params", (.gogoproto.nullable) = false];</code>
@@ -908,7 +908,7 @@ public final class GenesisProto {
       }
       /**
        * <pre>
-       * params defines all the paramaters related to swap
+       * params defines all the parameters related to swap
        * </pre>
        *
        * <code>.kava.swap.v1beta1.Params params = 1 [json_name = "params", (.gogoproto.nullable) = false];</code>
@@ -925,7 +925,7 @@ public final class GenesisProto {
       }
       /**
        * <pre>
-       * params defines all the paramaters related to swap
+       * params defines all the parameters related to swap
        * </pre>
        *
        * <code>.kava.swap.v1beta1.Params params = 1 [json_name = "params", (.gogoproto.nullable) = false];</code>
@@ -937,7 +937,7 @@ public final class GenesisProto {
       }
       /**
        * <pre>
-       * params defines all the paramaters related to swap
+       * params defines all the parameters related to swap
        * </pre>
        *
        * <code>.kava.swap.v1beta1.Params params = 1 [json_name = "params", (.gogoproto.nullable) = false];</code>
@@ -952,7 +952,7 @@ public final class GenesisProto {
       }
       /**
        * <pre>
-       * params defines all the paramaters related to swap
+       * params defines all the parameters related to swap
        * </pre>
        *
        * <code>.kava.swap.v1beta1.Params params = 1 [json_name = "params", (.gogoproto.nullable) = false];</code>


### PR DESCRIPTION
### Description

This PR corrects several minor typos in comments and documentation across the codebase. The changes are non-functional and purely textual to improve clarity and maintain a clean, professional codebase.

### Details

- Corrected misspellings:
  - `paramaters` → `parameters`

These fixes help enhance readability and eliminate minor distractions during development and code reviews.

### Additional Info

No logic or functionality has been modified. All changes are restricted to comments or non-executable doc annotations.