### PR TITLE
Fix typos in proto documentation

### DIFF
--- a/proto/src/main/java/com/babylon/incentive/RewardsProto.java
+++ b/proto/src/main/java/com/babylon/incentive/RewardsProto.java
@@ -21,8 +21,8 @@ public final class RewardsProto {
     /**
      * <pre>
      * The cumulative rewards of that finality provider per sat until that period
-     * This coins will aways increase the value, never be reduced due to keep
-     * acumulation and when the cumulative rewards will be used to distribute
+     * This coins will always increase the value, never be reduced due to keep
+     * accumulation and when the cumulative rewards will be used to distribute
      * rewards, 2 periods will be loaded, calculate the difference and multiplied
      * by the total sat amount delegated
      * https://github.com/cosmos/cosmos-sdk/blob/e76102f885b71fd6e1c1efb692052173c4b3c3a3/x/distribution/keeper/delegation.go#L47
@@ -35,8 +35,8 @@ public final class RewardsProto {
     /**
      * <pre>
      * The cumulative rewards of that finality provider per sat until that period
-     * This coins will aways increase the value, never be reduced due to keep
-     * acumulation and when the cumulative rewards will be used to distribute
+     * This coins will always increase the value, never be reduced due to keep
+     * accumulation and when the cumulative rewards will be used to distribute
      * rewards, 2 periods will be loaded, calculate the difference and multiplied
      * by the total sat amount delegated
      * https://github.com/cosmos/cosmos-sdk/blob/e76102f885b71fd6e1c1efb692052173c4b3c3a3/x/distribution/keeper/delegation.go#L47
@@ -48,8 +48,8 @@ public final class RewardsProto {
     /**
      * <pre>
      * The cumulative rewards of that finality provider per sat until that period
-     * This coins will aways increase the value, never be reduced due to keep
-     * acumulation and when the cumulative rewards will be used to distribute
+     * This coins will always increase the value, never be reduced due to keep
+     * accumulation and when the cumulative rewards will be used to distribute
      * rewards, 2 periods will be loaded, calculate the difference and multiplied
      * by the total sat amount delegated
      * https://github.com/cosmos/cosmos-sdk/blob/e76102f885b71fd6e1c1efb692052173c4b3c3a3/x/distribution/keeper/delegation.go#L47
@@ -61,8 +61,8 @@ public final class RewardsProto {
     /**
      * <pre>
      * The cumulative rewards of that finality provider per sat until that period
-     * This coins will aways increase the value, never be reduced due to keep
-     * acumulation and when the cumulative rewards will be used to distribute
+     * This coins will always increase the value, never be reduced due to keep
+     * accumulation and when the cumulative rewards will be used to distribute
      * rewards, 2 periods will be loaded, calculate the difference and multiplied
      * by the total sat amount delegated
      * https://github.com/cosmos/cosmos-sdk/blob/e76102f885b71fd6e1c1efb692052173c4b3c3a3/x/distribution/keeper/delegation.go#L47
@@ -75,8 +75,8 @@ public final class RewardsProto {
     /**
      * <pre>
      * The cumulative rewards of that finality provider per sat until that period
-     * This coins will aways increase the value, never be reduced due to keep
-     * acumulation and when the cumulative rewards will be used to distribute
+     * This coins will always increase the value, never be reduced due to keep
+     * accumulation and when the cumulative rewards will be used to distribute
      * rewards, 2 periods will be loaded, calculate the difference and multiplied
      * by the total sat amount delegated
      * https://github.com/cosmos/cosmos-sdk/blob/e76102f885b71fd6e1c1efb692052173c4b3c3a3/x/distribution/keeper/delegation.go#L47
@@ -90,7 +90,7 @@ public final class RewardsProto {
   /**
    * <pre>
    * FinalityProviderHistoricalRewards represents the cumulative rewards ratio of
-   * the finality provider per sat in that period. The period is ommited here and
+   * the finality provider per sat in that period. The period is omitted here and
    * should be part of the key used to store this structure. Key: Prefix +
    * Finality provider bech32 address + Period.
    * </pre>
@@ -136,8 +136,8 @@ public final class RewardsProto {
     /**
      * <pre>
      * The cumulative rewards of that finality provider per sat until that period
-     * This coins will aways increase the value, never be reduced due to keep
-     * acumulation and when the cumulative rewards will be used to distribute
+     * This coins will always increase the value, never be reduced due to keep
+     * accumulation and when the cumulative rewards will be used to distribute
      * rewards, 2 periods will be loaded, calculate the difference and multiplied
      * by the total sat amount delegated
      * https://github.com/cosmos/cosmos-sdk/blob/e76102f885b71fd6e1c1efb692052173c4b3c3a3/x/distribution/keeper/delegation.go#L47
@@ -152,8 +152,8 @@ public final class RewardsProto {
     /**
      * <pre>
      * The cumulative rewards of that finality provider per sat until that period
-     * This coins will aways increase the value, never be reduced due to keep
-     * acumulation and when the cumulative rewards will be used to distribute
+     * This coins will always increase the value, never be reduced due to keep
+     * accumulation and when the cumulative rewards will be used to distribute
      * rewards, 2 periods will be loaded, calculate the difference and multiplied
      * by the total sat amount delegated
      * https://github.com/cosmos/cosmos-sdk/blob/e76102f885b71fd6e1c1efb692052173c4b3c3a3/x/distribution/keeper/delegation.go#L47
@@ -169,8 +169,8 @@ public final class RewardsProto {
     /**
      * <pre>
      * The cumulative rewards of that finality provider per sat until that period
-     * This coins will aways increase the value, never be reduced due to keep
-     * acumulation and when the cumulative rewards will be used to distribute
+     * This coins will always increase the value, never be reduced due to keep
+     * accumulation and when the cumulative rewards will be used to distribute
      * rewards, 2 periods will be loaded, calculate the difference and multiplied
      * by the total sat amount delegated
      * https://github.com/cosmos/cosmos-sdk/blob/e76102f885b71fd6e1c1efb692052173c4b3c3a3/x/distribution/keeper/delegation.go#L47
@@ -185,8 +185,8 @@ public final class RewardsProto {
     /**
      * <pre>
      * The cumulative rewards of that finality provider per sat until that period
-     * This coins will aways increase the value, never be reduced due to keep
-     * acumulation and when the cumulative rewards will be used to distribute
+     * This coins will always increase the value, never be reduced due to keep
+     * accumulation and when the cumulative rewards will be used to distribute
      * rewards, 2 periods will be loaded, calculate the difference and multiplied
      * by the total sat amount delegated
      * https://github.com/cosmos/cosmos-sdk/blob/e76102f885b71fd6e1c1efb692052173c4b3c3a3/x/distribution/keeper/delegation.go#L47
@@ -201,8 +201,8 @@ public final class RewardsProto {
     /**
      * <pre>
      * The cumulative rewards of that finality provider per sat until that period
-     * This coins will aways increase the value, never be reduced due to keep
-     * acumulation and when the cumulative rewards will be used to distribute
+     * This coins will always increase the value, never be reduced due to keep
+     * accumulation and when the cumulative rewards will be used to distribute
      * rewards, 2 periods will be loaded, calculate the difference and multiplied
      * by the total sat amount delegated
      * https://github.com/cosmos/cosmos-sdk/blob/e76102f885b71fd6e1c1efb692052173c4b3c3a3/x/distribution/keeper/delegation.go#L47
@@ -378,7 +378,7 @@ public final class RewardsProto {
     /**
      * <pre>
      * FinalityProviderHistoricalRewards represents the cumulative rewards ratio of
-     * the finality provider per sat in that period. The period is ommited here and
+     * the finality provider per sat in that period. The period is omitted here and
      * should be part of the key used to store this structure. Key: Prefix +
      * Finality provider bech32 address + Period.
      * </pre>
@@ -612,8 +612,8 @@ public final class RewardsProto {
       /**
        * <pre>
        * The cumulative rewards of that finality provider per sat until that period
-       * This coins will aways increase the value, never be reduced due to keep
-       * acumulation and when the cumulative rewards will be used to distribute
+       * This coins will always increase the value, never be reduced due to keep
+       * accumulation and when the cumulative rewards will be used to distribute
        * rewards, 2 periods will be loaded, calculate the difference and multiplied
        * by the total sat amount delegated
        * https://github.com/cosmos/cosmos-sdk/blob/e76102f885b71fd6e1c1efb692052173c4b3c3a3/x/distribution/keeper/delegation.go#L47
@@ -631,8 +631,8 @@ public final class RewardsProto {
       /**
        * <pre>
        * The cumulative rewards of that finality provider per sat until that period
-       * This coins will aways increase the value, never be reduced due to keep
-       * acumulation and when the cumulative rewards will be used to distribute
+       * This coins will always increase the value, never be reduced due to keep
+       * accumulation and when the cumulative rewards will be used to distribute
        * rewards, 2 periods will be loaded, calculate the difference and multiplied
        * by the total sat amount delegated
        * https://github.com/cosmos/cosmos-sdk/blob/e76102f885b71fd6e1c1efb692052173c4b3c3a3/x/distribution/keeper/delegation.go#L47
@@ -650,8 +650,8 @@ public final class RewardsProto {
       /**
        * <pre>
        * The cumulative rewards of that finality provider per sat until that period
-       * This coins will aways increase the value, never be reduced due to keep
-       * acumulation and when the cumulative rewards will be used to distribute
+       * This coins will always increase the value, never be reduced due to keep
+       * accumulation and when the cumulative rewards will be used to distribute
        * rewards, 2 periods will be loaded, calculate the difference and multiplied
        * by the total sat amount delegated
        * https://github.com/cosmos/cosmos-sdk/blob/e76102f885b71fd6e1c1efb692052173c4b3c3a3/x/distribution/keeper/delegation.go#L47
@@ -669,8 +669,8 @@ public final class RewardsProto {
       /**
        * <pre>
        * The cumulative rewards of that finality provider per sat until that period
-       * This coins will aways increase the value, never be reduced due to keep
-       * acumulation and when the cumulative rewards will be used to distribute
+       * This coins will always increase the value, never be reduced due to keep
+       * accumulation and when the cumulative rewards will be used to distribute
        * rewards, 2 periods will be loaded, calculate the difference and multiplied
        * by the total sat amount delegated
        * https://github.com/cosmos/cosmos-sdk/blob/e76102f885b71fd6e1c1efb692052173c4b3c3a3/x/distribution/keeper/delegation.go#L47
@@ -695,8 +695,8 @@ public final class RewardsProto {
       /**
        * <pre>
        * The cumulative rewards of that finality provider per sat until that period
-       * This coins will aways increase the value, never be reduced due to keep
-       * acumulation and when the cumulative rewards will be used to distribute
+       * This coins will always increase the value, never be reduced due to keep
+       * accumulation and when the cumulative rewards will be used to distribute
        * rewards, 2 periods will be loaded, calculate the difference and multiplied
        * by the total sat amount delegated
        * https://github.com/cosmos/cosmos-sdk/blob/e76102f885b71fd6e1c1efb692052173c4b3c3a3/x/distribution/keeper/delegation.go#L47
@@ -718,8 +718,8 @@ public final class RewardsProto {
       /**
        * <pre>
        * The cumulative rewards of that finality provider per sat until that period
-       * This coins will aways increase the value, never be reduced due to keep
-       * acumulation and when the cumulative rewards will be used to distribute
+       * This coins will always increase the value, never be reduced due to keep
+       * accumulation and when the cumulative rewards will be used to distribute
        * rewards, 2 periods will be loaded, calculate the difference and multiplied
        * by the total sat amount delegated
        * https://github.com/cosmos/cosmos-sdk/blob/e76102f885b71fd6e1c1efb692052173c4b3c3a3/x/distribution/keeper/delegation.go#L47
@@ -743,8 +743,8 @@ public final class RewardsProto {
       /**
        * <pre>
        * The cumulative rewards of that finality provider per sat until that period
-       * This coins will aways increase the value, never be reduced due to keep
-       * acumulation and when the cumulative rewards will be used to distribute
+       * This coins will always increase the value, never be reduced due to keep
+       * accumulation and when the cumulative rewards will be used to distribute
        * rewards, 2 periods will be loaded, calculate the difference and multiplied
        * by the total sat amount delegated
        * https://github.com/cosmos/cosmos-sdk/blob/e76102f885b71fd6e1c1efb692052173c4b3c3a3/x/distribution/keeper/delegation.go#L47
@@ -769,8 +769,8 @@ public final class RewardsProto {
       /**
        * <pre>
        * The cumulative rewards of that finality provider per sat until that period
-       * This coins will aways increase the value, never be reduced due to keep
-       * acumulation and when the cumulative rewards will be used to distribute
+       * This coins will always increase the value, never be reduced due to keep
+       * accumulation and when the cumulative rewards will be used to distribute
        * rewards, 2 periods will be loaded, calculate the difference and multiplied
        * by the total sat amount delegated
        * https://github.com/cosmos/cosmos-sdk/blob/e76102f885b71fd6e1c1efb692052173c4b3c3a3/x/distribution/keeper/delegation.go#L47
@@ -792,8 +792,8 @@ public final class RewardsProto {
       /**
        * <pre>
        * The cumulative rewards of that finality provider per sat until that period
-       * This coins will aways increase the value, never be reduced due to keep
-       * acumulation and when the cumulative rewards will be used to distribute
+       * This coins will always increase the value, never be reduced due to keep
+       * accumulation and when the cumulative rewards will be used to distribute
        * rewards, 2 periods will be loaded, calculate the difference and multiplied
        * by the total sat amount delegated
        * https://github.com/cosmos/cosmos-sdk/blob/e76102f885b71fd6e1c1efb692052173c4b3c3a3/x/distribution/keeper/delegation.go#L47
@@ -815,8 +815,8 @@ public final class RewardsProto {
       /**
        * <pre>
        * The cumulative rewards of that finality provider per sat until that period
-       * This coins will aways increase the value, never be reduced due to keep
-       * acumulation and when the cumulative rewards will be used to distribute
+       * This coins will always increase the value, never be reduced due to keep
+       * accumulation and when the cumulative rewards will be used to distribute
        * rewards, 2 periods will be loaded, calculate the difference and multiplied
        * by the total sat amount delegated
        * https://github.com/cosmos/cosmos-sdk/blob/e76102f885b71fd6e1c1efb692052173c4b3c3a3/x/distribution/keeper/delegation.go#L47
@@ -839,8 +839,8 @@ public final class RewardsProto {
       /**
        * <pre>
        * The cumulative rewards of that finality provider per sat until that period
-       * This coins will aways increase the value, never be reduced due to keep
-       * acumulation and when the cumulative rewards will be used to distribute
+       * This coins will always increase the value, never be reduced due to keep
+       * accumulation and when the cumulative rewards will be used to distribute
        * rewards, 2 periods will be loaded, calculate the difference and multiplied
        * by the total sat amount delegated
        * https://github.com/cosmos/cosmos-sdk/blob/e76102f885b71fd6e1c1efb692052173c4b3c3a3/x/distribution/keeper/delegation.go#L47
@@ -861,8 +861,8 @@ public final class RewardsProto {
       /**
        * <pre>
        * The cumulative rewards of that finality provider per sat until that period
-       * This coins will aways increase the value, never be reduced due to keep
-       * acumulation and when the cumulative rewards will be used to distribute
+       * This coins will always increase the value, never be reduced due to keep
+       * accumulation and when the cumulative rewards will be used to distribute
        * rewards, 2 periods will be loaded, calculate the difference and multiplied
        * by the total sat amount delegated
        * https://github.com/cosmos/cosmos-sdk/blob/e76102f885b71fd6e1c1efb692052173c4b3c3a3/x/distribution/keeper/delegation.go#L47
@@ -883,8 +883,8 @@ public final class RewardsProto {
       /**
        * <pre>
        * The cumulative rewards of that finality provider per sat until that period
-       * This coins will aways increase the value, never be reduced due to keep
-       * acumulation and when the cumulative rewards will be used to distribute
+       * This coins will always increase the value, never be reduced due to keep
+       * accumulation and when the cumulative rewards will be used to distribute
        * rewards, 2 periods will be loaded, calculate the difference and multiplied
        * by the total sat amount delegated
        * https://github.com/cosmos/cosmos-sdk/blob/e76102f885b71fd6e1c1efb692052173c4b3c3a3/x/distribution/keeper/delegation.go#L47
@@ -899,8 +899,8 @@ public final class RewardsProto {
       /**
        * <pre>
        * The cumulative rewards of that finality provider per sat until that period
-       * This coins will aways increase the value, never be reduced due to keep
-       * acumulation and when the cumulative rewards will be used to distribute
+       * This coins will always increase the value, never be reduced due to keep
+       * accumulation and when the cumulative rewards will be used to distribute
        * rewards, 2 periods will be loaded, calculate the difference and multiplied
        * by the total sat amount delegated
        * https://github.com/cosmos/cosmos-sdk/blob/e76102f885b71fd6e1c1efb692052173c4b3c3a3/x/distribution/keeper/delegation.go#L47
@@ -918,8 +918,8 @@ public final class RewardsProto {
       /**
        * <pre>
        * The cumulative rewards of that finality provider per sat until that period
-       * This coins will aways increase the value, never be reduced due to keep
-       * acumulation and when the cumulative rewards will be used to distribute
+       * This coins will always increase the value, never be reduced due to keep
+       * accumulation and when the cumulative rewards will be used to distribute
        * rewards, 2 periods will be loaded, calculate the difference and multiplied
        * by the total sat amount delegated
        * https://github.com/cosmos/cosmos-sdk/blob/e76102f885b71fd6e1c1efb692052173c4b3c3a3/x/distribution/keeper/delegation.go#L47
@@ -938,8 +938,8 @@ public final class RewardsProto {
       /**
        * <pre>
        * The cumulative rewards of that finality provider per sat until that period
-       * This coins will aways increase the value, never be reduced due to keep
-       * acumulation and when the cumulative rewards will be used to distribute
+       * This coins will always increase the value, never be reduced due to keep
+       * accumulation and when the cumulative rewards will be used to distribute
        * rewards, 2 periods will be loaded, calculate the difference and multiplied
        * by the total sat amount delegated
        * https://github.com/cosmos/cosmos-sdk/blob/e76102f885b71fd6e1c1efb692052173c4b3c3a3/x/distribution/keeper/delegation.go#L47
@@ -954,8 +954,8 @@ public final class RewardsProto {
       /**
        * <pre>
        * The cumulative rewards of that finality provider per sat until that period
-       * This coins will aways increase the value, never be reduced due to keep
-       * acumulation and when the cumulative rewards will be used to distribute
+       * This coins will always increase the value, never be reduced due to keep
+       * accumulation and when the cumulative rewards will be used to distribute
        * rewards, 2 periods will be loaded, calculate the difference and multiplied
        * by the total sat amount delegated
        * https://github.com/cosmos/cosmos-sdk/blob/e76102f885b71fd6e1c1efb692052173c4b3c3a3/x/distribution/keeper/delegation.go#L47
@@ -971,8 +971,8 @@ public final class RewardsProto {
       /**
        * <pre>
        * The cumulative rewards of that finality provider per sat until that period
-       * This coins will aways increase the value, never be reduced due to keep
-       * acumulation and when the cumulative rewards will be used to distribute
+       * This coins will always increase the value, never be reduced due to keep
+       * accumulation and when the cumulative rewards will be used to distribute
        * rewards, 2 periods will be loaded, calculate the difference and multiplied
        * by the total sat amount delegated
        * https://github.com/cosmos/cosmos-sdk/blob/e76102f885b71fd6e1c1efb692052173c4b3c3a3/x/distribution/keeper/delegation.go#L47

--- a/proto/src/main/java/com/initia/mstaking/v1/StakingProto.java
+++ b/proto/src/main/java/com/initia/mstaking/v1/StakingProto.java
@@ -3878,7 +3878,7 @@ public final class StakingProto {
 
     /**
      * <pre>
-     * unbonding id, uniquely identifing an unbonding of this validator
+     * unbonding id, uniquely identifying an unbonding of this validator
      * </pre>
      *
      * <code>uint64 unbonding_id = 14 [json_name = "unbondingId"];</code>
@@ -4442,7 +4442,7 @@ public final class StakingProto {
     private long unbondingId_ = 0L;
     /**
      * <pre>
-     * unbonding id, uniquely identifing an unbonding of this validator
+     * unbonding id, uniquely identifying an unbonding of this validator
      * </pre>
      *
      * <code>uint64 unbonding_id = 14 [json_name = "unbondingId"];</code>
@@ -7232,7 +7232,7 @@ public final class StakingProto {
       private long unbondingId_ ;
       /**
        * <pre>
-       * unbonding id, uniquely identifing an unbonding of this validator
+       * unbonding id, uniquely identifying an unbonding of this validator
        * </pre>
        *
        * <code>uint64 unbonding_id = 14 [json_name = "unbondingId"];</code>
@@ -7244,7 +7244,7 @@ public final class StakingProto {
       }
       /**
        * <pre>
-       * unbonding id, uniquely identifing an unbonding of this validator
+       * unbonding id, uniquely identifying an unbonding of this validator
        * </pre>
        *
        * <code>uint64 unbonding_id = 14 [json_name = "unbondingId"];</code>
@@ -7260,7 +7260,7 @@ public final class StakingProto {
       }
       /**
        * <pre>
-       * unbonding id, uniquely identifing an unbonding of this validator
+       * unbonding id, uniquely identifying an unbonding of this validator
        * </pre>
        *
        * <code>uint64 unbonding_id = 14 [json_name = "unbondingId"];</code>

--- a/proto/src/main/java/com/kava/swap/v1beta1/TxProto.java
+++ b/proto/src/main/java/com/kava/swap/v1beta1/TxProto.java
@@ -3600,7 +3600,7 @@ public final class TxProto {
 
     /**
      * <pre>
-     * represents the address swaping the tokens
+     * represents the address swapping the tokens
      * </pre>
      *
      * <code>string requester = 1 [json_name = "requester", (.cosmos_proto.scalar) = "cosmos.AddressString"];</code>
@@ -3609,7 +3609,7 @@ public final class TxProto {
     java.lang.String getRequester();
     /**
      * <pre>
-     * represents the address swaping the tokens
+     * represents the address swapping the tokens
      * </pre>
      *
      * <code>string requester = 1 [json_name = "requester", (.cosmos_proto.scalar) = "cosmos.AddressString"];</code>
@@ -3748,7 +3748,7 @@ public final class TxProto {
     private volatile java.lang.Object requester_ = "";
     /**
      * <pre>
-     * represents the address swaping the tokens
+     * represents the address swapping the tokens
      * </pre>
      *
      * <code>string requester = 1 [json_name = "requester", (.cosmos_proto.scalar) = "cosmos.AddressString"];</code>
@@ -3769,7 +3769,7 @@ public final class TxProto {
     }
     /**
      * <pre>
-     * represents the address swaping the tokens
+     * represents the address swapping the tokens
      * </pre>
      *
      * <code>string requester = 1 [json_name = "requester", (.cosmos_proto.scalar) = "cosmos.AddressString"];</code>
@@ -4381,7 +4381,7 @@ public final class TxProto {
       private java.lang.Object requester_ = "";
       /**
        * <pre>
-       * represents the address swaping the tokens
+       * represents the address swapping the tokens
        * </pre>
        *
        * <code>string requester = 1 [json_name = "requester", (.cosmos_proto.scalar) = "cosmos.AddressString"];</code>
@@ -4401,7 +4401,7 @@ public final class TxProto {
       }
       /**
        * <pre>
-       * represents the address swaping the tokens
+       * represents the address swapping the tokens
        * </pre>
        *
        * <code>string requester = 1 [json_name = "requester", (.cosmos_proto.scalar) = "cosmos.AddressString"];</code>
@@ -4422,7 +4422,7 @@ public final class TxProto {
       }
       /**
        * <pre>
-       * represents the address swaping the tokens
+       * represents the address swapping the tokens
        * </pre>
        *
        * <code>string requester = 1 [json_name = "requester", (.cosmos_proto.scalar) = "cosmos.AddressString"];</code>
@@ -4439,7 +4439,7 @@ public final class TxProto {
       }
       /**
        * <pre>
-       * represents the address swaping the tokens
+       * represents the address swapping the tokens
        * </pre>
        *
        * <code>string requester = 1 [json_name = "requester", (.cosmos_proto.scalar) = "cosmos.AddressString"];</code>
@@ -4453,7 +4453,7 @@ public final class TxProto {
       }
       /**
        * <pre>
-       * represents the address swaping the tokens
+       * represents the address swapping the tokens
        * </pre>
        *
        * <code>string requester = 1 [json_name = "requester", (.cosmos_proto.scalar) = "cosmos.AddressString"];</code>
@@ -5392,7 +5392,7 @@ public final class TxProto {
 
     /**
      * <pre>
-     * represents the address swaping the tokens
+     * represents the address swapping the tokens
      * </pre>
      *
      * <code>string requester = 1 [json_name = "requester", (.cosmos_proto.scalar) = "cosmos.AddressString"];</code>
@@ -5401,7 +5401,7 @@ public final class TxProto {
     java.lang.String getRequester();
     /**
      * <pre>
-     * represents the address swaping the tokens
+     * represents the address swapping the tokens
      * </pre>
      *
      * <code>string requester = 1 [json_name = "requester", (.cosmos_proto.scalar) = "cosmos.AddressString"];</code>
@@ -5541,7 +5541,7 @@ public final class TxProto {
     private volatile java.lang.Object requester_ = "";
     /**
      * <pre>
-     * represents the address swaping the tokens
+     * represents the address swapping the tokens
      * </pre>
      *
      * <code>string requester = 1 [json_name = "requester", (.cosmos_proto.scalar) = "cosmos.AddressString"];</code>
@@ -5562,7 +5562,7 @@ public final class TxProto {
     }
     /**
      * <pre>
-     * represents the address swaping the tokens
+     * represents the address swapping the tokens
      * </pre>
      *
      * <code>string requester = 1 [json_name = "requester", (.cosmos_proto.scalar) = "cosmos.AddressString"];</code>
@@ -6175,7 +6175,7 @@ public final class TxProto {
       private java.lang.Object requester_ = "";
       /**
        * <pre>
-       * represents the address swaping the tokens
+       * represents the address swapping the tokens
        * </pre>
        *
        * <code>string requester = 1 [json_name = "requester", (.cosmos_proto.scalar) = "cosmos.AddressString"];</code>
@@ -6195,7 +6195,7 @@ public final class TxProto {
       }
       /**
        * <pre>
-       * represents the address swaping the tokens
+       * represents the address swapping the tokens
        * </pre>
        *
        * <code>string requester = 1 [json_name = "requester", (.cosmos_proto.scalar) = "cosmos.AddressString"];</code>
@@ -6216,7 +6216,7 @@ public final class TxProto {
       }
       /**
        * <pre>
-       * represents the address swaping the tokens
+       * represents the address swapping the tokens
        * </pre>
        *
        * <code>string requester = 1 [json_name = "requester", (.cosmos_proto.scalar) = "cosmos.AddressString"];</code>
@@ -6233,7 +6233,7 @@ public final class TxProto {
       }
       /**
        * <pre>
-       * represents the address swaping the tokens
+       * represents the address swapping the tokens
        * </pre>
        *
        * <code>string requester = 1 [json_name = "requester", (.cosmos_proto.scalar) = "cosmos.AddressString"];</code>
@@ -6247,7 +6247,7 @@ public final class TxProto {
       }
       /**
        * <pre>
-       * represents the address swaping the tokens
+       * represents the address swapping the tokens
        * </pre>
        *
        * <code>string requester = 1 [json_name = "requester", (.cosmos_proto.scalar) = "cosmos.AddressString"];</code>


### PR DESCRIPTION
Corrects spelling errors in proto file documentation comments:

  - `aways` → `always`
  - `acumulation` → `accumulation`
  - `ommited` → `omitted`
  - `identifing` → `identifying`
  - `swaping` → `swapping`