### PR TITLE
Fix typos in comment and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ You can download each store.
 	 	
   <tr>
     <td><img src="https://github.com/cosmostation/chainlist/blob/main/chain/archway/resource/chain_archway.png?raw=true" width="42" height = "42"></td>
-    <td><span style="font-weight:bold">ARCHYWAY</span></td>
+    <td><span style="font-weight:bold">ARCHWAY</span></td>
     <td>m/44'/118'/0'/0/X</td>
     <td>secp256k1</td>
     <td>gRPC or Rest</td>

--- a/proto/src/main/java/com/cosmos/gov/v1/GovProto.java
+++ b/proto/src/main/java/com/cosmos/gov/v1/GovProto.java
@@ -2649,7 +2649,7 @@ public final class GovProto {
 
     /**
      * <pre>
-     * Proposer is the address of the proposal sumbitter
+     * Proposer is the address of the proposal submitter
      *
      * Since: cosmos-sdk 0.47
      * </pre>
@@ -2660,7 +2660,7 @@ public final class GovProto {
     java.lang.String getProposer();
     /**
      * <pre>
-     * Proposer is the address of the proposal sumbitter
+     * Proposer is the address of the proposal submitter
      *
      * Since: cosmos-sdk 0.47
      * </pre>
@@ -3230,7 +3230,7 @@ public final class GovProto {
     private volatile java.lang.Object proposer_ = "";
     /**
      * <pre>
-     * Proposer is the address of the proposal sumbitter
+     * Proposer is the address of the proposal submitter
      *
      * Since: cosmos-sdk 0.47
      * </pre>
@@ -3253,7 +3253,7 @@ public final class GovProto {
     }
     /**
      * <pre>
-     * Proposer is the address of the proposal sumbitter
+     * Proposer is the address of the proposal submitter
      *
      * Since: cosmos-sdk 0.47
      * </pre>
@@ -5877,7 +5877,7 @@ public final class GovProto {
       private java.lang.Object proposer_ = "";
       /**
        * <pre>
-       * Proposer is the address of the proposal sumbitter
+       * Proposer is the address of the proposal submitter
        *
        * Since: cosmos-sdk 0.47
        * </pre>
@@ -5899,7 +5899,7 @@ public final class GovProto {
       }
       /**
        * <pre>
-       * Proposer is the address of the proposal sumbitter
+       * Proposer is the address of the proposal submitter
        *
        * Since: cosmos-sdk 0.47
        * </pre>
@@ -5922,7 +5922,7 @@ public final class GovProto {
       }
       /**
        * <pre>
-       * Proposer is the address of the proposal sumbitter
+       * Proposer is the address of the proposal submitter
        *
        * Since: cosmos-sdk 0.47
        * </pre>
@@ -5941,7 +5941,7 @@ public final class GovProto {
       }
       /**
        * <pre>
-       * Proposer is the address of the proposal sumbitter
+       * Proposer is the address of the proposal submitter
        *
        * Since: cosmos-sdk 0.47
        * </pre>
@@ -5957,7 +5957,7 @@ public final class GovProto {
       }
       /**
        * <pre>
-       * Proposer is the address of the proposal sumbitter
+       * Proposer is the address of the proposal submitter
        *
        * Since: cosmos-sdk 0.47
        * </pre>

--- a/proto/src/main/java/com/cosmos/staking/v1beta1/StakingProto.java
+++ b/proto/src/main/java/com/cosmos/staking/v1beta1/StakingProto.java
@@ -23990,7 +23990,7 @@ public final class StakingProto {
 
     /**
      * <pre>
-     * height defines the block height at which the rotation event occured.
+     * height defines the block height at which the rotation event occurred.
      * </pre>
      *
      * <code>uint64 height = 4 [json_name = "height"];</code>
@@ -24192,7 +24192,7 @@ public final class StakingProto {
     private long height_ = 0L;
     /**
      * <pre>
-     * height defines the block height at which the rotation event occured.
+     * height defines the block height at which the rotation event occurred.
      * </pre>
      *
      * <code>uint64 height = 4 [json_name = "height"];</code>
@@ -25108,7 +25108,7 @@ public final class StakingProto {
       private long height_ ;
       /**
        * <pre>
-       * height defines the block height at which the rotation event occured.
+       * height defines the block height at which the rotation event occurred.
        * </pre>
        *
        * <code>uint64 height = 4 [json_name = "height"];</code>
@@ -25120,7 +25120,7 @@ public final class StakingProto {
       }
       /**
        * <pre>
-       * height defines the block height at which the rotation event occured.
+       * height defines the block height at which the rotation event occurred.
        * </pre>
        *
        * <code>uint64 height = 4 [json_name = "height"];</code>
@@ -25136,7 +25136,7 @@ public final class StakingProto {
       }
       /**
        * <pre>
-       * height defines the block height at which the rotation event occured.
+       * height defines the block height at which the rotation event occurred.
        * </pre>
        *
        * <code>uint64 height = 4 [json_name = "height"];</code>

--- a/proto/src/main/java/com/initia/gov/v1/GovProto.java
+++ b/proto/src/main/java/com/initia/gov/v1/GovProto.java
@@ -7773,7 +7773,7 @@ public final class GovProto {
 
     /**
      * <pre>
-     * proposer is the address of the proposal sumbitter
+     * proposer is the address of the proposal submitter
      *
      * Since: cosmos-sdk 0.47
      * </pre>
@@ -7784,7 +7784,7 @@ public final class GovProto {
     java.lang.String getProposer();
     /**
      * <pre>
-     * proposer is the address of the proposal sumbitter
+     * proposer is the address of the proposal submitter
      *
      * Since: cosmos-sdk 0.47
      * </pre>
@@ -8453,7 +8453,7 @@ public final class GovProto {
     private volatile java.lang.Object proposer_ = "";
     /**
      * <pre>
-     * proposer is the address of the proposal sumbitter
+     * proposer is the address of the proposal submitter
      *
      * Since: cosmos-sdk 0.47
      * </pre>
@@ -8476,7 +8476,7 @@ public final class GovProto {
     }
     /**
      * <pre>
-     * proposer is the address of the proposal sumbitter
+     * proposer is the address of the proposal submitter
      *
      * Since: cosmos-sdk 0.47
      * </pre>
@@ -11571,7 +11571,7 @@ public final class GovProto {
       private java.lang.Object proposer_ = "";
       /**
        * <pre>
-       * proposer is the address of the proposal sumbitter
+       * proposer is the address of the proposal submitter
        *
        * Since: cosmos-sdk 0.47
        * </pre>
@@ -11593,7 +11593,7 @@ public final class GovProto {
       }
       /**
        * <pre>
-       * proposer is the address of the proposal sumbitter
+       * proposer is the address of the proposal submitter
        *
        * Since: cosmos-sdk 0.47
        * </pre>
@@ -11616,7 +11616,7 @@ public final class GovProto {
       }
       /**
        * <pre>
-       * proposer is the address of the proposal sumbitter
+       * proposer is the address of the proposal submitter
        *
        * Since: cosmos-sdk 0.47
        * </pre>
@@ -11635,7 +11635,7 @@ public final class GovProto {
       }
       /**
        * <pre>
-       * proposer is the address of the proposal sumbitter
+       * proposer is the address of the proposal submitter
        *
        * Since: cosmos-sdk 0.47
        * </pre>
@@ -11651,7 +11651,7 @@ public final class GovProto {
       }
       /**
        * <pre>
-       * proposer is the address of the proposal sumbitter
+       * proposer is the address of the proposal submitter
        *
        * Since: cosmos-sdk 0.47
        * </pre>

--- a/proto/src/main/java/com/stratos/evm/v1/TxProto.java
+++ b/proto/src/main/java/com/stratos/evm/v1/TxProto.java
@@ -2309,7 +2309,7 @@ public final class TxProto {
        * </pre>
        *
        * <code>string to = 4 [json_name = "to"];</code>
-       * @param value The to to set.
+       * @param value The to set.
        * @return This builder for chaining.
        */
       public Builder setTo(
@@ -4153,7 +4153,7 @@ public final class TxProto {
        * </pre>
        *
        * <code>string to = 5 [json_name = "to"];</code>
-       * @param value The to to set.
+       * @param value The to set.
        * @return This builder for chaining.
        */
       public Builder setTo(
@@ -6421,7 +6421,7 @@ public final class TxProto {
        * </pre>
        *
        * <code>string to = 6 [json_name = "to"];</code>
-       * @param value The to to set.
+       * @param value The to set.
        * @return This builder for chaining.
        */
       public Builder setTo(


### PR DESCRIPTION
Corrected several spelling errors in code comments and docs:

- ARCHYWAY → ARCHWAY
- sumbitter → submitter
- occured → occurred
- The to to set → The to set
