### PR TITLE
 Add grpcHost for Lava Network

### DIFF
--- a/app/src/main/java/wannabit/io/cosmostaion/chain/cosmosClass/ChainLava.kt
+++ b/app/src/main/java/wannabit/io/cosmostaion/chain/cosmosClass/ChainLava.kt
@@ -25,6 +25,6 @@ class ChainLava : BaseChain(), Parcelable {
     override var cosmosEndPointType: CosmosEndPointType? = CosmosEndPointType.USE_LCD
     override var stakeDenom: String = "ulava"
     override var accountPrefix: String = "lava@"
-    override var grpcHost: String = ""
+    override var grpcHost: String = "lava-grpc.publicnode.com:443"
     override var lcdUrl: String = "https://lava-api.w3coins.io/"
 }


### PR DESCRIPTION
 Description:
  Add missing gRPC endpoint for Lava Network from official Cosmos Chain Registry.
 Changes:
  - Updated grpcHost from empty string to lava-grpc.publicnode.com:443 in ChainLava.kt