### PR TITLE
 Add grpcHost for Comdex

### DIFF
--- a/app/src/main/java/wannabit/io/cosmostaion/chain/cosmosClass/ChainComdex.kt
+++ b/app/src/main/java/wannabit/io/cosmostaion/chain/cosmosClass/ChainComdex.kt
@@ -25,6 +25,6 @@ class ChainComdex : BaseChain(), Parcelable {
     override var cosmosEndPointType: CosmosEndPointType? = CosmosEndPointType.USE_LCD
     override var stakeDenom: String = "ucmdx"
     override var accountPrefix: String = "comdex"
-    override var grpcHost: String = ""
+    override var grpcHost: String = "comdex-grpc.publicnode.com:443"
     override var lcdUrl: String = "https://comdex.api.m.stavr.tech/"
 }


### PR DESCRIPTION
 Add missing gRPC endpoint for Comdex from official Cosmos Chain Registry.
Updated grpcHost from empty string to comdex-grpc.publicnode.com:443 in ChainComdex.kt