### PR TITLE
Configure gRPC endpoints for chains

### DIFF
--- a/app/src/main/java/wannabit/io/cosmostaion/chain/cosmosClass/ChainArkeo.kt
+++ b/app/src/main/java/wannabit/io/cosmostaion/chain/cosmosClass/ChainArkeo.kt
@@ -24,6 +24,6 @@ class ChainArkeo : BaseChain(), Parcelable {
     override var cosmosEndPointType: CosmosEndPointType? = CosmosEndPointType.USE_LCD
     override var stakeDenom: String = "uarkeo"
     override var accountPrefix: String = "arkeo"
-    override var grpcHost: String = ""
+    override var grpcHost: String = "arkeo-grpc.publicnode.com:443"
     override var lcdUrl: String = "https://rest-seed.arkeo.network/"
 }

--- a/app/src/main/java/wannabit/io/cosmostaion/chain/cosmosClass/ChainBeezee.kt
+++ b/app/src/main/java/wannabit/io/cosmostaion/chain/cosmosClass/ChainBeezee.kt
@@ -24,6 +24,6 @@ class ChainBeezee : BaseChain(), Parcelable {
     override var cosmosEndPointType: CosmosEndPointType? = CosmosEndPointType.USE_LCD
     override var stakeDenom: String = "ubze"
     override var accountPrefix: String = "bze"
-    override var grpcHost: String = ""
+    override var grpcHost: String = "beezee-grpc.publicnode.com:443"
     override var lcdUrl: String = "https://rest.getbze.com/"
 }

--- a/app/src/main/java/wannabit/io/cosmostaion/chain/cosmosClass/ChainCarbon.kt
+++ b/app/src/main/java/wannabit/io/cosmostaion/chain/cosmosClass/ChainCarbon.kt
@@ -25,6 +25,6 @@ class ChainCarbon : BaseChain(), Parcelable {
     override var cosmosEndPointType: CosmosEndPointType? = CosmosEndPointType.USE_LCD
     override var stakeDenom: String = "swth"
     override var accountPrefix: String = "swth"
-    override var grpcHost: String = ""
+    override var grpcHost: String = "carbon-grpc.publicnode.com:443"
     override var lcdUrl: String = "https://api.carbon.network/"
 }

--- a/app/src/main/java/wannabit/io/cosmostaion/chain/cosmosClass/ChainDesmos.kt
+++ b/app/src/main/java/wannabit/io/cosmostaion/chain/cosmosClass/ChainDesmos.kt
@@ -24,6 +24,6 @@ class ChainDesmos : BaseChain(), Parcelable {
     override var cosmosEndPointType: CosmosEndPointType? = CosmosEndPointType.USE_LCD
     override var stakeDenom: String = "udsm"
     override var accountPrefix: String = "desmos"
-    override var grpcHost: String = ""
+    override var grpcHost: String = "desmos-grpc.publicnode.com:443"
     override var lcdUrl: String = "https://desmos-rest.staketab.org/"
 }


### PR DESCRIPTION
Adds gRPC endpoint configurations for Arkeo, BeeZee, Carbon, and Desmos chains using publicnode.com infrastructure.

These chains previously had empty `grpcHost` values, making gRPC communication impossible despite `CosmosEndPointType.USE_LCD` being set. The update enables proper node connectivity:

- **Arkeo**: `arkeo-grpc.publicnode.com:443`
- **BeeZee**: `beezee-grpc.publicnode.com:443`  
- **Carbon**: `carbon-grpc.publicnode.com:443`
- **Desmos**: `desmos-grpc.publicnode.com:443`

