### PR TITLE
Refactor Hippocrat path and Airchains config

### DIFF
--- a/app/src/main/java/wannabit/io/cosmostaion/chain/cosmosClass/ChainHippocrat.kt
+++ b/app/src/main/java/wannabit/io/cosmostaion/chain/cosmosClass/ChainHippocrat.kt
@@ -18,7 +18,7 @@ class ChainHippocrat : BaseChain(), Parcelable {
 
     override var accountKeyType = AccountKeyType(PubKeyType.COSMOS_SECP256K1, "m/44'/0'/0'/0/X")
     override var setParentPath: List<ChildNumber> = ImmutableList.of(
-        ChildNumber(44, true), ChildNumber(0, true), ChildNumber.ZERO_HARDENED, ChildNumber.ZERO
+        ChildNumber(44, true), ChildNumber.ZERO_HARDENED, ChildNumber.ZERO_HARDENED, ChildNumber.ZERO
     )
 
     override var cosmosEndPointType: CosmosEndPointType? = CosmosEndPointType.USE_GRPC


### PR DESCRIPTION
Standardizes [ChainHippocrat](cci:2://file:///d:/friendly-project/cosmostation-android/app/src/main/java/wannabit/io/cosmostaion/chain/cosmosClass/ChainHippocrat.kt:11:0-28:1) to use `ChildNumber.ZERO_HARDENED`, eliminating an inconsistent magic number found only in this file and aligning it with the pervasive pattern across the codebase.