### PR TITLE
Refactor Lists and Magic Numbers

### DIFF
--- a/app/src/main/java/wannabit/io/cosmostaion/chain/cosmosClass/ChainAirchains.kt
+++ b/app/src/main/java/wannabit/io/cosmostaion/chain/cosmosClass/ChainAirchains.kt
@@ -1,7 +1,7 @@
 package wannabit.io.cosmostaion.chain.cosmosClass
 
 import android.os.Parcelable
-import com.google.common.collect.ImmutableList
+
 import kotlinx.parcelize.Parcelize
 import org.bitcoinj.crypto.ChildNumber
 import wannabit.io.cosmostaion.chain.AccountKeyType
@@ -17,7 +17,7 @@ open class ChainAirchains : BaseChain(), Parcelable {
     override var apiName: String = "airchains"
 
     override var accountKeyType = AccountKeyType(PubKeyType.COSMOS_SECP256K1, "m/44'/118'/0'/0/X")
-    override var setParentPath: List<ChildNumber> = ImmutableList.of(
+    override var setParentPath: List<ChildNumber> = listOf(
         ChildNumber(44, true), ChildNumber(118, true), ChildNumber.ZERO_HARDENED, ChildNumber.ZERO
     )
 

--- a/app/src/main/java/wannabit/io/cosmostaion/chain/cosmosClass/ChainArkeo.kt
+++ b/app/src/main/java/wannabit/io/cosmostaion/chain/cosmosClass/ChainArkeo.kt
@@ -1,7 +1,7 @@
 package wannabit.io.cosmostaion.chain.cosmosClass
 
 import android.os.Parcelable
-import com.google.common.collect.ImmutableList
+
 import kotlinx.parcelize.Parcelize
 import org.bitcoinj.crypto.ChildNumber
 import wannabit.io.cosmostaion.chain.AccountKeyType
@@ -17,7 +17,7 @@ class ChainArkeo : BaseChain(), Parcelable {
     override var apiName: String = "arkeo"
 
     override var accountKeyType = AccountKeyType(PubKeyType.COSMOS_SECP256K1, "m/44'/118'/0'/0/X")
-    override var setParentPath: List<ChildNumber> = ImmutableList.of(
+    override var setParentPath: List<ChildNumber> = listOf(
         ChildNumber(44, true), ChildNumber(118, true), ChildNumber.ZERO_HARDENED, ChildNumber.ZERO
     )
 

--- a/app/src/main/java/wannabit/io/cosmostaion/chain/cosmosClass/ChainCosmos.kt
+++ b/app/src/main/java/wannabit/io/cosmostaion/chain/cosmosClass/ChainCosmos.kt
@@ -1,7 +1,7 @@
 package wannabit.io.cosmostaion.chain.cosmosClass
 
 import android.os.Parcelable
-import com.google.common.collect.ImmutableList
+
 import kotlinx.parcelize.Parcelize
 import org.bitcoinj.crypto.ChildNumber
 import wannabit.io.cosmostaion.R
@@ -18,7 +18,7 @@ class ChainCosmos : BaseChain(), Parcelable {
     override var apiName: String = "cosmos"
 
     override var accountKeyType = AccountKeyType(PubKeyType.COSMOS_SECP256K1, "m/44'/118'/0'/0/X")
-    override var setParentPath: List<ChildNumber> = ImmutableList.of(
+    override var setParentPath: List<ChildNumber> = listOf(
         ChildNumber(44, true), ChildNumber(118, true), ChildNumber.ZERO_HARDENED, ChildNumber.ZERO
     )
 

--- a/app/src/main/java/wannabit/io/cosmostaion/chain/cosmosClass/ChainHippocrat.kt
+++ b/app/src/main/java/wannabit/io/cosmostaion/chain/cosmosClass/ChainHippocrat.kt
@@ -1,7 +1,7 @@
 package wannabit.io.cosmostaion.chain.cosmosClass
 
 import android.os.Parcelable
-import com.google.common.collect.ImmutableList
+
 import kotlinx.parcelize.Parcelize
 import org.bitcoinj.crypto.ChildNumber
 import wannabit.io.cosmostaion.chain.AccountKeyType
@@ -17,7 +17,7 @@ class ChainHippocrat : BaseChain(), Parcelable {
     override var apiName: String = "hippocrat"
 
     override var accountKeyType = AccountKeyType(PubKeyType.COSMOS_SECP256K1, "m/44'/0'/0'/0/X")
-    override var setParentPath: List<ChildNumber> = ImmutableList.of(
+    override var setParentPath: List<ChildNumber> = listOf(
         ChildNumber(44, true), ChildNumber.ZERO_HARDENED, ChildNumber.ZERO_HARDENED, ChildNumber.ZERO
     )
 

--- a/app/src/main/java/wannabit/io/cosmostaion/chain/cosmosClass/ChainKava118.kt
+++ b/app/src/main/java/wannabit/io/cosmostaion/chain/cosmosClass/ChainKava118.kt
@@ -1,7 +1,7 @@
 package wannabit.io.cosmostaion.chain.cosmosClass
 
 import android.os.Parcelable
-import com.google.common.collect.ImmutableList
+
 import kotlinx.parcelize.Parcelize
 import org.bitcoinj.crypto.ChildNumber
 import wannabit.io.cosmostaion.chain.AccountKeyType
@@ -15,7 +15,7 @@ class ChainKava118 : ChainKava459(), Parcelable {
     override var isDefault: Boolean = false
 
     override var accountKeyType = AccountKeyType(PubKeyType.COSMOS_SECP256K1, "m/44'/118'/0'/0/X")
-    override var setParentPath: List<ChildNumber> = ImmutableList.of(
+    override var setParentPath: List<ChildNumber> = listOf(
         ChildNumber(44, true), ChildNumber(118, true), ChildNumber.ZERO_HARDENED, ChildNumber.ZERO
     )
 


### PR DESCRIPTION
Replaces Guava's `ImmutableList.of` with Kotlin's native `listOf` in several Chain classes. This reduces library dependency and aligns with standard Kotlin practices.